### PR TITLE
Replace AWS NAT Gateway with Gateway Instance pattern

### DIFF
--- a/deploy/aws-ec2/README.md
+++ b/deploy/aws-ec2/README.md
@@ -71,6 +71,33 @@ If you're happy with the proposed changes, deploy the stack:
 cdk deploy
 ```
 
+## SSH
+
+You can SSH through the NAT instance using a `~/.ssh/config` setup similar to the following:
+
+```
+Host tokenized-nat tokenised-nat
+Hostname 1.2.3.4
+User ec2-user
+IdentityFile ~/.ssh/tokenized-ssh
+IdentitiesOnly yes
+
+Host tokenized tokenised
+Hostname 10.0.111.195
+User ec2-user
+IdentityFile ~/.ssh/tokenized-ssh
+IdentitiesOnly yes
+ProxyCommand ssh -A tokenized-nat -W %h:%p
+```
+
+Note: Make sure you set the public IP of your NAT gateway + private IP of your tokenized server correctly.
+
+Then you can just connect with:
+
+```
+ssh tokenized
+```
+
 ## Config
 
 `config.template` uses [mustache](https://mustache.github.io/) template syntax to [generate the config file at deploy time](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-init.html#aws-resource-init-files).

--- a/deploy/aws-ec2/bin/tokenized.ts
+++ b/deploy/aws-ec2/bin/tokenized.ts
@@ -41,11 +41,17 @@ class TokenizedEC2Stack extends cdk.Stack {
 
         natSecurityGroup.tags.setTag("Name", natSecurityGroup.path);
 
-        if (props.enableSSH) {
-            // Allow ssh access
-            // Ref: https://awslabs.github.io/aws-cdk/refs/_aws-cdk_aws-ec2.html#allowing-connections
-            natSecurityGroup.connections.allowFromAnyIPv4(new ec2.TcpPort(22));
-        }
+        // TODO: Is this ok?
+        natSecurityGroup.connections.allowFromAnyIPv4(new ec2.TcpAllPorts());
+
+        // Ref: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html#nacl-ephemeral-ports
+        // natSecurityGroup.connections.allowFromAnyIPv4(new ec2.TcpPortRange(32768, 65535));
+
+        // if (props.enableSSH) {
+        //     // Allow ssh access
+        //     // Ref: https://awslabs.github.io/aws-cdk/refs/_aws-cdk_aws-ec2.html#allowing-connections
+        //     natSecurityGroup.connections.allowFromAnyIPv4(new ec2.TcpPort(22));
+        // }
 
         // Ref: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html
         // Ref: https://awslabs.github.io/aws-cdk/refs/_aws-cdk_aws-ec2.html#@aws-cdk/aws-ec2.SecurityGroupProps
@@ -93,10 +99,13 @@ class TokenizedEC2Stack extends cdk.Stack {
             // }
         });
 
+        // Ref: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html#nacl-ephemeral-ports
+        appAsg.connections.allowFromAnyIPv4(new ec2.TcpPortRange(32768, 65535));
+
         if (props.enableSSH) {
             // Allow ssh access
             // Ref: https://awslabs.github.io/aws-cdk/refs/_aws-cdk_aws-ec2.html#allowing-connections
-            appAsg.connections.allowFrom(natSecurityGroup, new ec2.TcpPort(22))
+            appAsg.connections.allowFromAnyIPv4(new ec2.TcpPort(22));
         }
 
         // Ref: https://awslabs.github.io/aws-cdk/refs/_aws-cdk_assets.html


### PR DESCRIPTION
While the AWS NAT Gateway is a good product for large scale deployments, that reality is that it's a really expensive service for smaller scale projects.

This PR replaces the NAT Gateway with a NAT instance pattern (the way we did things before the NAT Gateway was a product), and allows you to choose the instance size it runs on (eg. `t3.micro`)

Also fixed a bug in the way EC2 `UserData` was being formatted, causing the server to not set itself up correctly.

**Ref**

* https://github.com/awslabs/aws-cdk/issues/1305
* https://github.com/awslabs/aws-cdk/issues/1309