### PR TITLE
Fix the STN magic bytes.

### DIFF
--- a/pkg/bitcoin/network.go
+++ b/pkg/bitcoin/network.go
@@ -12,7 +12,7 @@ type Network uint32
 const (
 	MainNet       Network = 0xe8f3e1e3
 	TestNet       Network = 0xf4f3e5f4
-	StressTestNet Network = 0xfbcec4f9
+	StressTestNet Network = 0xf9c4cefb
 )
 
 var (


### PR DESCRIPTION
Although they were stated as reported by bitcoinscaling.io, they
are expected to be in reverse order.