### PR TITLE
Improve cli parse command.

### DIFF
--- a/pkg/spynode/handlers/data/tx_tracker.go
+++ b/pkg/spynode/handlers/data/tx_tracker.go
@@ -2,8 +2,8 @@ package data
 
 import (
 	"context"
-	"time"
 	"sync"
+	"time"
 
 	"github.com/tokenized/smart-contract/pkg/bitcoin"
 	"github.com/tokenized/smart-contract/pkg/logger"


### PR DESCRIPTION
Make cli parse able to parse only the op return script as well as decode the asset and message payloads.