### PR TITLE
Add key id to txbuilder outputs.

### DIFF
--- a/pkg/txbuilder/fees.go
+++ b/pkg/txbuilder/fees.go
@@ -145,7 +145,11 @@ func (tx *TxBuilder) adjustFee(amount int64) (bool, error) {
 		if changeOutputIndex == 0xffffffff {
 			// Add a change output if it would be more than the dust limit
 			if uint64(-amount) > tx.DustLimit {
-				tx.AddPaymentOutput(tx.ChangeAddress, uint64(-amount), true)
+				err := tx.AddPaymentOutput(tx.ChangeAddress, uint64(-amount), true)
+				if err != nil {
+					return false, err
+				}
+				tx.Outputs[len(tx.Outputs)-1].KeyID = tx.ChangeKeyID
 				tx.Outputs[len(tx.Outputs)-1].addedForFee = true
 			} else {
 				done = true

--- a/pkg/txbuilder/inputs.go
+++ b/pkg/txbuilder/inputs.go
@@ -87,6 +87,7 @@ func (tx *TxBuilder) AddFunding(utxos []bitcoin.UTXO) error {
 				if err != nil {
 					return errors.Wrap(err, "adding change")
 				}
+				tx.Outputs[len(tx.Outputs)-1].KeyID = tx.ChangeKeyID
 			}
 			funding = 0
 			break

--- a/pkg/txbuilder/outputs.go
+++ b/pkg/txbuilder/outputs.go
@@ -9,9 +9,12 @@ import (
 
 // OutputSupplement contains data that
 type OutputSupplement struct {
-	IsChange    bool
-	IsDust      bool
+	IsChange    bool `json:"is_change"`
+	IsDust      bool `json:"is_dust"`
 	addedForFee bool
+
+	// Optional identifier for external use to track the key needed to spend.
+	KeyID string `json:"key_id,omitempty"`
 }
 
 // AddPaymentOutput adds an output to TxBuilder with the specified value and a script paying the

--- a/pkg/txbuilder/txbuilder.go
+++ b/pkg/txbuilder/txbuilder.go
@@ -23,6 +23,9 @@ type TxBuilder struct {
 	ChangeAddress bitcoin.RawAddress  // The address to pay extra bitcoins to if a change output isn't specified
 	DustLimit     uint64              // Smallest amount of bitcoin for a valid spendable output
 	FeeRate       float32             // The target fee rate in sat/byte
+
+	// Optional identifier for external use to track the key needed to spend change
+	ChangeKeyID   string
 }
 
 // NewTx returns a new TxBuilder with the specified change PKH
@@ -76,6 +79,7 @@ func NewTxBuilderFromWire(changeAddress bitcoin.RawAddress, dustLimit uint64, fe
 		newOutput := OutputSupplement{
 			IsChange: bytes.Equal(output.PkScript, changeScript),
 			IsDust:   false,
+			KeyID:    result.ChangeKeyID,
 		}
 		result.Outputs = append(result.Outputs, &newOutput)
 	}


### PR DESCRIPTION
Add key id to txbuilder outputs so that change and other outputs can be identified as relating to specific keys.