### PR TITLE
Corrected the size used for P2PKH inputs.

### DIFF
--- a/cmd/smartcontractd/handlers/message.go
+++ b/cmd/smartcontractd/handlers/message.go
@@ -227,7 +227,7 @@ func (m *Message) ProcessRevert(ctx context.Context, w *node.ResponseWriter,
 	tx.AddOutput(payload, 0, false, false)
 
 	// Estimate fee with 2 inputs
-	amount := tx.EstimatedFee() + outputAmount + (2 * txbuilder.EstimatedP2PKHInputSize)
+	amount := tx.EstimatedFee() + outputAmount + (2 * txbuilder.MaximumP2PKHInputSize)
 
 	for {
 		utxos, err := m.UTXOs.Get(amount, rk.Address)

--- a/pkg/txbuilder/fees.go
+++ b/pkg/txbuilder/fees.go
@@ -8,10 +8,10 @@ import (
 )
 
 const (
-	// P2PKH/P2SH input size 146
+	// P2PKH/P2SH input size 149
 	//   Previous Transaction ID = 32 bytes
 	//   Previous Transaction Output Index = 4 bytes
-	//   script size = 2 bytes
+	//   script size = 1 byte
 	//   Signature push to stack = 74
 	//       push size = 1 byte
 	//       signature up to = 72 bytes
@@ -19,7 +19,8 @@ const (
 	//   Public key push to stack = 34
 	//       push size = 1 byte
 	//       public key size = 33 bytes
-	EstimatedP2PKHInputSize = 32 + 4 + 2 + 74 + 34
+	//   Sequence number = 4
+	MaximumP2PKHInputSize = 32 + 4 + 1 + 74 + 34 + 4
 
 	// Size of output not including script
 	OutputBaseSize = 8
@@ -59,7 +60,7 @@ func (tx *TxBuilder) EstimatedSize() int {
 		if len(input.SignatureScript) > 0 {
 			result += input.SerializeSize()
 		} else {
-			result += EstimatedP2PKHInputSize // TODO Update when non-P2PKH inputs are implemented
+			result += MaximumP2PKHInputSize // TODO Update when non-P2PKH inputs are implemented
 		}
 	}
 

--- a/pkg/txbuilder/inputs.go
+++ b/pkg/txbuilder/inputs.go
@@ -95,7 +95,7 @@ func (tx *TxBuilder) AddFunding(utxos []bitcoin.UTXO) error {
 	// Calculate additional funding needed. Include cost of first added input.
 	// TODO Add support for input scripts other than P2PKH.
 	neededFunding := estFeeValue + outputValue - inputValue
-	estInputFee := uint64(float32(EstimatedP2PKHInputSize) * tx.FeeRate)
+	estInputFee := uint64(float32(MaximumP2PKHInputSize) * tx.FeeRate)
 	estOutputFee := uint64(float32(P2PKHOutputSize) * tx.FeeRate)
 	neededFunding += estInputFee
 	if changeOutputIndex == 0xffffffff {
@@ -137,7 +137,7 @@ func (tx *TxBuilder) AddFunding(utxos []bitcoin.UTXO) error {
 		}
 
 		// Add cost of next input
-		neededFunding += uint64(float32(EstimatedP2PKHInputSize) * tx.FeeRate)
+		neededFunding += uint64(float32(MaximumP2PKHInputSize) * tx.FeeRate)
 	}
 
 	if tx.SendMax {


### PR DESCRIPTION
The estimate for the size of the P2PKH now uses the maximum size so that there is no need for a safety margin for the fee rate. The fee rate will always be at least what is specified, or higher when the actual input size is smaller.

The name was changed from EstimatedP2PKHInputSize to MaximumP2PKHINputSize to indicate how the estimate was obtained, and how it can be wrong (be being too high, but not by being too low.) 