### PR TITLE
Update new address and script template codes.

### DIFF
--- a/cmd/smartcontract/cmd/cmd_code.go
+++ b/cmd/smartcontract/cmd/cmd_code.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
-	"crypto/sha256"
+	"crypto/rand"
 	"fmt"
 
+	"github.com/btcsuite/btcutil/base58"
 	"github.com/spf13/cobra"
 )
 
@@ -12,20 +13,47 @@ var cmdCode = &cobra.Command{
 	Short: "Run random code",
 	RunE: func(c *cobra.Command, args []string) error {
 
-		hash := sha256.Sum256([]byte("secret"))
-		key := make([]byte, 0)
-		key = append(key, hash[:16]...)
-		fmt.Printf("%x = SHA256(\"secret\")\n", hash)
+		rb := make([]byte, 24)
+		rand.Read(rb)
 
-		hash = sha256.Sum256(hash[:])
-		key = append(key, hash[:16]...)
-		fmt.Printf("CHC[1] = %x\n", hash)
+		fmt.Printf("P2PKH Main 0x00 = %s\n", base58.Encode(append([]byte{0x00}, rb...)))
+		fmt.Printf("P2PKH Test 0x6f = %s\n", base58.Encode(append([]byte{0x6f}, rb...)))
+		fmt.Printf("P2SH Main 0x05 = %s\n", base58.Encode(append([]byte{0x05}, rb...)))
+		fmt.Printf("P2SH Test 0xc4 = %s\n", base58.Encode(append([]byte{0xc4}, rb...)))
+		fmt.Printf("\n")
+		fmt.Printf("R Puzzle Main 0x7b = r = %s\n", base58.Encode(append([]byte{0x7b}, rb...)))
+		fmt.Printf("R Puzzle Test 0x7d = s = %s\n", base58.Encode(append([]byte{0x7d}, rb...)))
+		fmt.Printf("Multi PKH Main 0x76 = p = %s\n", base58.Encode(append([]byte{0x76}, rb...)))
+		fmt.Printf("Multi PKH Test 0x78 = q = %s\n", base58.Encode(append([]byte{0x78}, rb...)))
 
-		hash = sha256.Sum256(hash[:])
-		key = append(key, hash[:16]...)
-		fmt.Printf("CHC[2] = %x\n", hash)
+		// for i := 0; i < 256; i++ {
+		// 	for j := 0; j < 3; j++ {
+		// 		rand.Read(rb)
+		// 		data := append([]byte{byte(i)}, rb...)
+		// 		fmt.Printf("0x%x = %s\n", i, base58.Encode(data))
+		// 	}
+		// }
 
-		fmt.Printf("Cipher Key = %x\n", key)
+		// for i := 0; i < 256; i++ {
+		// 	rand.Read(rb)
+		// 	data := append([]byte{0x25, byte(i)}, rb...)
+		// 	fmt.Printf("0x%x = %s\n", 0x25, base58.Encode(data))
+		// }
+
+		// hash := sha256.Sum256([]byte("secret"))
+		// key := make([]byte, 0)
+		// key = append(key, hash[:16]...)
+		// fmt.Printf("%x = SHA256(\"secret\")\n", hash)
+		//
+		// hash = sha256.Sum256(hash[:])
+		// key = append(key, hash[:16]...)
+		// fmt.Printf("CHC[1] = %x\n", hash)
+		//
+		// hash = sha256.Sum256(hash[:])
+		// key = append(key, hash[:16]...)
+		// fmt.Printf("CHC[2] = %x\n", hash)
+		//
+		// fmt.Printf("Cipher Key = %x\n", key)
 		return nil
 	},
 }

--- a/pkg/bitcoin/address.go
+++ b/pkg/bitcoin/address.go
@@ -15,15 +15,15 @@ var (
 )
 
 const (
-	AddressTypeMainPKH      = 0x00 // Public Key Hash
-	AddressTypeMainSH       = 0x05 // Script Hash
-	AddressTypeMainMultiPKH = 0x10 // Multi-PKH - Experimental value. Not standard
-	AddressTypeMainRPH      = 0x20 // RPH - Experimental value. Not standard
+	AddressTypeMainPKH      = 0x00 // Public Key Hash (starts with 1)
+	AddressTypeMainSH       = 0x05 // Script Hash (starts with 3)
+	AddressTypeMainMultiPKH = 0x76 // Multi-PKH (starts with p) - Experimental value. Not standard
+	AddressTypeMainRPH      = 0x7b // RPH (starts with r) - Experimental value. Not standard
 
-	AddressTypeTestPKH      = 0x6f // Testnet Public Key Hash
-	AddressTypeTestSH       = 0xc4 // Testnet Script Hash
-	AddressTypeTestMultiPKH = 0xd0 // Multi-PKH - Experimental value. Not standard
-	AddressTypeTestRPH      = 0xe0 // RPH - Experimental value. Not standard
+	AddressTypeTestPKH      = 0x6f // Testnet Public Key Hash (starts with m or n)
+	AddressTypeTestSH       = 0xc4 // Testnet Script Hash (starts with 2)
+	AddressTypeTestMultiPKH = 0x78 // Multi-PKH (starts with q) - Experimental value. Not standard
+	AddressTypeTestRPH      = 0x7d // RPH (starts with s) - Experimental value. Not standard
 )
 
 type Address struct {

--- a/pkg/bitcoin/raw_address.go
+++ b/pkg/bitcoin/raw_address.go
@@ -9,10 +9,10 @@ import (
 )
 
 const (
-	ScriptTypePKH      = 0x30 // Public Key Hash
-	ScriptTypeSH       = 0x31 // Script Hash
-	ScriptTypeMultiPKH = 0x32 // Multi-PKH
-	ScriptTypeRPH      = 0x33 // RPH
+	ScriptTypePKH      = 0x20 // Public Key Hash
+	ScriptTypeSH       = 0x21 // Script Hash
+	ScriptTypeMultiPKH = 0x22 // Multi-PKH
+	ScriptTypeRPH      = 0x23 // RPH
 
 	ScriptHashLength = 20 // Length of standard public key, script, and R hashes RIPEMD(SHA256())
 )


### PR DESCRIPTION
Update codes for new address types and internal script templates to ensure there are no conflicts with other known data formats. Specifically DER signatures start with 0x30 and script template code for P2PKH was 0x30.

Others thought of:
private keys are 0x00
WIF private keys are 0x80 and 0xef
pub keys are 0x02 or 0x03
xpubs start with 0x04
existing addresses start with 0x00, 0x05, 0x6f, and 0xc4