### PR TITLE
Change recovery processing to store requests until chain is synced. #48

### DIFF
--- a/cmd/smartcontractd/listeners/listener.go
+++ b/cmd/smartcontractd/listeners/listener.go
@@ -124,17 +124,13 @@ func (server *Server) HandleInSync(ctx context.Context) error {
 	node.Log(ctx, "Node is in sync")
 	server.inSync = true
 
-	// Send pending responses
-	pending := server.pendingResponses
-	server.pendingResponses = nil
-
+	// Process pending requests
+	pending := server.pendingRequests
+	server.pendingRequests = nil
 	for _, pendingTx := range pending {
-		node.Log(ctx, "Sending pending response: %s", pendingTx.TxHash().String())
-		if err := server.sendTx(ctx, pendingTx); err != nil {
-			if err != nil {
-				node.LogWarn(ctx, "Failed to send tx : %s", err)
-			}
-			return nil // TODO Probably a fatal error
+		node.Log(ctx, "Processing pending request: %s", pendingTx.Itx.Hash.String())
+		if err := server.Handler.Trigger(ctx, "SEE", pendingTx.Itx); err != nil {
+			node.LogError(ctx, "Failed to handle pending request tx : %s", err)
 		}
 	}
 


### PR DESCRIPTION
There was slight potential that a smart contract could not resync properly to the chain after losing off chain state data. This scenario had to happen.

1. Multiple requests were sent to the smart contract, some of which conflict with each other. For example two sends that each by themselves are valid, but that together total more than the amount owned.
2. One is processed by the smart contract and the other is not.
3. The smart contract is taken down and the off chain state is cleared.
4. When the smart contract is brought back online it sees the unprocessed tx before the processed txs. So it accepts the unprocessed tx even though, in combination with the other, it is invalid.

This is because previously the smart contract built responses to txs before it was in sync and held onto them until it was in sync, clearing them if it sees a pre-existing response. This assumed it would see everything in the same order and create the same responses to any previously processed txs.

Now instead it saves the requests while syncing, and when it is in sync, it processes any requests that have not yet been responded to.