### PR TITLE
Fix cleanup

### DIFF
--- a/cmd/smartcontractd/tests/asset_test.go
+++ b/cmd/smartcontractd/tests/asset_test.go
@@ -722,7 +722,7 @@ var sampleAssetPayload2 = assets.ShareCommon{
 }
 
 var sampleAdminAssetPayload = assets.Membership{
-	MembershipClass: "Owner",
+	MembershipClass: "Administrator",
 	Description:     "Test admin token",
 }
 

--- a/cmd/smartcontractd/tests/transfer_test.go
+++ b/cmd/smartcontractd/tests/transfer_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/tokenized/smart-contract/pkg/wire"
 
 	"github.com/tokenized/specification/dist/golang/actions"
-	"github.com/tokenized/specification/dist/golang/assets"
 	"github.com/tokenized/specification/dist/golang/messages"
 	"github.com/tokenized/specification/dist/golang/protocol"
 )
@@ -1548,7 +1547,7 @@ func oracleTransferBad(t *testing.T) {
 	bitcoinTransferAmount := uint64(50000)
 	bitcoinTransferData := actions.AssetTransferField{
 		ContractIndex: uint32(0x0000ffff),
-		AssetType:     assets.CodeCurrency,
+		AssetType:     "BSV",
 	}
 
 	bitcoinTransferData.AssetSenders = append(bitcoinTransferData.AssetSenders,

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -104,6 +104,9 @@ func Update(ctx context.Context, dbConn *db.DB, contractAddress bitcoin.RawAddre
 	if upd.AdminMemberAsset != nil {
 		c.AdminMemberAsset = *upd.AdminMemberAsset
 	}
+	if upd.OwnerMemberAsset != nil {
+		c.OwnerMemberAsset = *upd.OwnerMemberAsset
+	}
 
 	if upd.ContractName != nil {
 		c.ContractName = *upd.ContractName

--- a/internal/contract/models.go
+++ b/internal/contract/models.go
@@ -52,6 +52,7 @@ type UpdateContract struct {
 	OperatorAddress       *bitcoin.RawAddress `json:"OperatorAddress,omitempty"`
 
 	AdminMemberAsset *protocol.AssetCode `json:"AdminMemberAsset,omitempty"`
+	OwnerMemberAsset *protocol.AssetCode `json:"OwnerMemberAsset,omitempty"`
 
 	ContractName              *string                       `json:"ContractName,omitempty"`
 	BodyOfAgreementType       *uint32                       `json:"BodyOfAgreementType,omitempty"`

--- a/internal/platform/state/models.go
+++ b/internal/platform/state/models.go
@@ -21,6 +21,7 @@ type Contract struct {
 	MovedTo               bitcoin.RawAddress `json:"MovedTo,omitempty"`
 
 	AdminMemberAsset protocol.AssetCode `json:"AdminMemberAsset,omitempty"`
+	OwnerMemberAsset protocol.AssetCode `json:"OwnerMemberAsset,omitempty"`
 
 	ContractName              string                       `json:"ContractName,omitempty"`
 	BodyOfAgreementType       uint32                       `json:"BodyOfAgreementType,omitempty"`

--- a/pkg/txbuilder/txbuilder_test.go
+++ b/pkg/txbuilder/txbuilder_test.go
@@ -390,8 +390,8 @@ func TestSendMax(t *testing.T) {
 		t.Fatalf("Failed to build max send tx : %s", err)
 	}
 
-	tx.AddPaymentOutput(toAddress, 600, false)
-	tx.AddPaymentOutput(toAddress2, 0, true)
+	tx.AddPaymentOutput(toAddress, 1000, false)
+	tx.AddOutput(toScript2, 0, true, false)
 
 	tx.SetSendMax()
 	err = tx.AddFunding(utxos[:1])
@@ -425,7 +425,7 @@ func TestSendMax(t *testing.T) {
 		t.Fatalf("Failed to build max send tx : %s", err)
 	}
 
-	tx.AddPaymentOutput(toAddress, 0, true)
+	tx.AddOutput(toScript, 0, true, false)
 
 	tx.SetSendMax()
 	err = tx.AddFunding(utxos)
@@ -460,7 +460,7 @@ func TestSendMax(t *testing.T) {
 	}
 
 	tx.AddPaymentOutput(toAddress, 5000, false)
-	tx.AddPaymentOutput(toAddress2, 0, true)
+	tx.AddOutput(toScript2, 0, true, false)
 
 	tx.SetSendMax()
 	err = tx.AddFunding(utxos)


### PR DESCRIPTION
Fix a few bugs related to bitcoin asset types and dust limits.

Update Owner and Administrator Membership tokens so that there can only be one of each, but only Administrator tokens are used in Administrative Matter votes.