### PR TITLE
Improve CLI and fix some minor issues

### DIFF
--- a/cmd/smartcontract/client/node.go
+++ b/cmd/smartcontract/client/node.go
@@ -79,9 +79,9 @@ func Context() context.Context {
 	return logger.ContextWithLogConfig(ctx, logConfig)
 }
 
-func NewClient(ctx context.Context, network string) (*Client, error) {
-	if len(network) == 0 {
-		return nil, errors.New("No Bitcoin network specified")
+func NewClient(ctx context.Context, network bitcoin.Network) (*Client, error) {
+	if network == bitcoin.InvalidNet {
+		return nil, errors.New("Invalid Bitcoin network specified")
 	}
 	client := Client{}
 
@@ -91,7 +91,7 @@ func NewClient(ctx context.Context, network string) (*Client, error) {
 		return nil, err
 	}
 
-	client.Config.Net = bitcoin.NetworkFromString(network)
+	client.Config.Net = network
 
 	// -------------------------------------------------------------------------
 	// Wallet

--- a/cmd/smartcontract/cmd/cmd_convert.go
+++ b/cmd/smartcontract/cmd/cmd_convert.go
@@ -18,10 +18,10 @@ var cmdConvert = &cobra.Command{
 		}
 
 		network := network(c)
-		if len(network) == 0 {
+		if network == bitcoin.InvalidNet {
+			fmt.Printf("Invalid network specified")
 			return nil
 		}
-		net := bitcoin.NetworkFromString(network)
 
 		address, err := bitcoin.DecodeAddress(args[0])
 		if err == nil {
@@ -46,7 +46,7 @@ var cmdConvert = &cobra.Command{
 			return nil
 		}
 		if n == 20 {
-			address, err = bitcoin.NewAddressPKH(hash[:20], net)
+			address, err = bitcoin.NewAddressPKH(hash[:20], network)
 			if err != nil {
 				fmt.Printf("Invalid hash : %s\n", err)
 				return nil
@@ -60,7 +60,7 @@ var cmdConvert = &cobra.Command{
 				fmt.Printf("Invalid hash : %s\n", err)
 				return nil
 			}
-			address := bitcoin.NewAddressFromRawAddress(rawAddress, net)
+			address := bitcoin.NewAddressFromRawAddress(rawAddress, network)
 			fmt.Printf("Address : %s\n", address.String())
 			return nil
 		}

--- a/cmd/smartcontract/cmd/cmd_gen.go
+++ b/cmd/smartcontract/cmd/cmd_gen.go
@@ -19,18 +19,18 @@ var cmdGen = &cobra.Command{
 		}
 
 		network := network(c)
-		if len(network) == 0 {
+		if network == bitcoin.InvalidNet {
+			fmt.Printf("Invalid network specified")
 			return nil
 		}
-		net := bitcoin.NetworkFromString(network)
 
-		key, err := bitcoin.GenerateKeyS256(net)
+		key, err := bitcoin.GenerateKeyS256(network)
 		if err != nil {
 			fmt.Printf("Failed to generate key : %s\n", err)
 			return nil
 		}
 
-		address, err := bitcoin.NewAddressPKH(bitcoin.Hash160(key.PublicKey().Bytes()), net)
+		address, err := bitcoin.NewAddressPKH(bitcoin.Hash160(key.PublicKey().Bytes()), network)
 		if err != nil {
 			fmt.Printf("Failed to generate address : %s\n", err)
 			return nil

--- a/cmd/smartcontract/cmd/main.go
+++ b/cmd/smartcontract/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/tokenized/smart-contract/internal/platform/node"
+	"github.com/tokenized/smart-contract/pkg/bitcoin"
 	"github.com/tokenized/smart-contract/pkg/json"
 
 	"github.com/tokenized/specification/dist/golang/protocol"
@@ -47,12 +48,14 @@ func Context() context.Context {
 }
 
 // network returns the network string. It is necessary because cobra default values don't seem to work.
-func network(c *cobra.Command) string {
+func network(c *cobra.Command) bitcoin.Network {
 	network := os.Getenv("BITCOIN_CHAIN")
 	if len(network) == 0 {
-		fmt.Printf("WARNING!! No Bitcoin network specified. Set environment value BITCOIN_CHAIN=testnet\n")
+		fmt.Printf("WARNING!! No Bitcoin network specified. Defaulting to mainnet. To change set environment value BITCOIN_CHAIN=testnet\n")
+		return bitcoin.MainNet
 	}
-	return network
+
+	return bitcoin.NetworkFromString(network)
 }
 
 // dumpJSON pretty prints a JSON representation of a struct.

--- a/cmd/smartcontractd/tests/asset_test.go
+++ b/cmd/smartcontractd/tests/asset_test.go
@@ -722,7 +722,7 @@ var sampleAssetPayload2 = assets.ShareCommon{
 }
 
 var sampleAdminAssetPayload = assets.Membership{
-	MembershipClass: "Owner",
+	MembershipClass: "Administrator",
 	Description:     "Test admin token",
 }
 

--- a/cmd/smartcontractd/tests/transfer_test.go
+++ b/cmd/smartcontractd/tests/transfer_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/tokenized/smart-contract/pkg/wire"
 
 	"github.com/tokenized/specification/dist/golang/actions"
-	"github.com/tokenized/specification/dist/golang/assets"
 	"github.com/tokenized/specification/dist/golang/messages"
 	"github.com/tokenized/specification/dist/golang/protocol"
 )
@@ -1548,7 +1547,7 @@ func oracleTransferBad(t *testing.T) {
 	bitcoinTransferAmount := uint64(50000)
 	bitcoinTransferData := actions.AssetTransferField{
 		ContractIndex: uint32(0x0000ffff),
-		AssetType:     assets.CodeCurrency,
+		AssetType:     "BSV",
 	}
 
 	bitcoinTransferData.AssetSenders = append(bitcoinTransferData.AssetSenders,

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -104,6 +104,9 @@ func Update(ctx context.Context, dbConn *db.DB, contractAddress bitcoin.RawAddre
 	if upd.AdminMemberAsset != nil {
 		c.AdminMemberAsset = *upd.AdminMemberAsset
 	}
+	if upd.OwnerMemberAsset != nil {
+		c.OwnerMemberAsset = *upd.OwnerMemberAsset
+	}
 
 	if upd.ContractName != nil {
 		c.ContractName = *upd.ContractName

--- a/internal/contract/models.go
+++ b/internal/contract/models.go
@@ -52,6 +52,7 @@ type UpdateContract struct {
 	OperatorAddress       *bitcoin.RawAddress `json:"OperatorAddress,omitempty"`
 
 	AdminMemberAsset *protocol.AssetCode `json:"AdminMemberAsset,omitempty"`
+	OwnerMemberAsset *protocol.AssetCode `json:"OwnerMemberAsset,omitempty"`
 
 	ContractName              *string                       `json:"ContractName,omitempty"`
 	BodyOfAgreementType       *uint32                       `json:"BodyOfAgreementType,omitempty"`

--- a/internal/platform/state/models.go
+++ b/internal/platform/state/models.go
@@ -21,6 +21,7 @@ type Contract struct {
 	MovedTo               bitcoin.RawAddress `json:"MovedTo,omitempty"`
 
 	AdminMemberAsset protocol.AssetCode `json:"AdminMemberAsset,omitempty"`
+	OwnerMemberAsset protocol.AssetCode `json:"OwnerMemberAsset,omitempty"`
 
 	ContractName              string                       `json:"ContractName,omitempty"`
 	BodyOfAgreementType       uint32                       `json:"BodyOfAgreementType,omitempty"`

--- a/pkg/bitcoin/network.go
+++ b/pkg/bitcoin/network.go
@@ -13,6 +13,7 @@ const (
 	MainNet       Network = 0xe8f3e1e3
 	TestNet       Network = 0xf4f3e5f4
 	StressTestNet Network = 0xf9c4cefb
+	InvalidNet    Network = 0x00000000
 )
 
 var (
@@ -36,7 +37,7 @@ func NetworkFromString(name string) Network {
 		return StressTestNet
 	}
 
-	return TestNet
+	return InvalidNet
 }
 
 func NetworkName(net Network) string {

--- a/pkg/txbuilder/fees.go
+++ b/pkg/txbuilder/fees.go
@@ -28,9 +28,9 @@ const (
 	// P2PKH/P2SH output size 33
 	//   amount = 8 bytes
 	//   script size = 1 byte
-	//   Script (24 bytes) OP_DUP OP_HASH160 <PUB KEY/SCRIPT HASH (20 bytes)> OP_EQUALVERIFY
+	//   Script (25 bytes) OP_DUP OP_HASH160 <Push Data byte, PUB KEY/SCRIPT HASH (20 bytes)> OP_EQUALVERIFY
 	//     OP_CHECKSIG
-	P2PKHOutputSize = OutputBaseSize + 25
+	P2PKHOutputSize = OutputBaseSize + 26
 
 	// BaseTxFee is the size of the tx not included in inputs and outputs.
 	//   Version = 4 bytes

--- a/pkg/txbuilder/txbuilder_test.go
+++ b/pkg/txbuilder/txbuilder_test.go
@@ -390,8 +390,8 @@ func TestSendMax(t *testing.T) {
 		t.Fatalf("Failed to build max send tx : %s", err)
 	}
 
-	tx.AddPaymentOutput(toAddress, 600, false)
-	tx.AddPaymentOutput(toAddress2, 0, true)
+	tx.AddPaymentOutput(toAddress, 1000, false)
+	tx.AddOutput(toScript2, 0, true, false)
 
 	tx.SetSendMax()
 	err = tx.AddFunding(utxos[:1])
@@ -425,7 +425,7 @@ func TestSendMax(t *testing.T) {
 		t.Fatalf("Failed to build max send tx : %s", err)
 	}
 
-	tx.AddPaymentOutput(toAddress, 0, true)
+	tx.AddOutput(toScript, 0, true, false)
 
 	tx.SetSendMax()
 	err = tx.AddFunding(utxos)
@@ -460,7 +460,7 @@ func TestSendMax(t *testing.T) {
 	}
 
 	tx.AddPaymentOutput(toAddress, 5000, false)
-	tx.AddPaymentOutput(toAddress2, 0, true)
+	tx.AddOutput(toScript2, 0, true, false)
 
 	tx.SetSendMax()
 	err = tx.AddFunding(utxos)


### PR DESCRIPTION
Add a stdin option to CLI parse command.
Change network specification message to default to mainnet, but function as a warning of the default.

The below updates are from a lost branch that I just realized was never pushed.
Fix a few missing updates to asset type for bitcoin transfers.
Fix txbuilder tests.
Update owner and administrator membership classes so they can both exist simultaneously and only the administrator asset will be used for administrative matter votes.