### PR TITLE
Update Transfers

### DIFF
--- a/cmd/smartcontractd/handlers/transfer.go
+++ b/cmd/smartcontractd/handlers/transfer.go
@@ -73,24 +73,26 @@ func (t *Transfer) TransferRequest(ctx context.Context, w *node.ResponseWriter,
 
 	if itx.RejectCode != 0 {
 		node.LogWarn(ctx, "Transfer request invalid")
-		return respondTransferReject(ctx, t.MasterDB, t.Config, w, itx, msg, rk, itx.RejectCode, false)
+		return respondTransferReject(ctx, t.MasterDB, t.Config, w, itx, msg, rk, itx.RejectCode,
+			false, "")
 	}
 
 	// Check pre-processing reject code
 	if itx.RejectCode != 0 {
-		return respondTransferReject(ctx, t.MasterDB, t.Config, w, itx, msg, rk, itx.RejectCode, false)
+		return respondTransferReject(ctx, t.MasterDB, t.Config, w, itx, msg, rk, itx.RejectCode,
+			false, "")
 	}
 
 	if msg.OfferExpiry != 0 && v.Now.Nano() > msg.OfferExpiry {
 		node.LogWarn(ctx, "Transfer expired : %d", msg.OfferExpiry)
 		return respondTransferReject(ctx, t.MasterDB, t.Config, w, itx, msg, rk,
-			actions.RejectionsTransferExpired, false)
+			actions.RejectionsTransferExpired, false, "")
 	}
 
 	if len(msg.Assets) == 0 {
 		node.LogWarn(ctx, "Transfer has no asset transfers")
 		return respondTransferReject(ctx, t.MasterDB, t.Config, w, itx, msg, rk,
-			actions.RejectionsTransferExpired, false)
+			actions.RejectionsMsgMalformed, false, "No transfers")
 	}
 
 	// Bitcoin balance of first (this) contract. Funding for bitcoin transfers.
@@ -110,19 +112,19 @@ func (t *Transfer) TransferRequest(ctx context.Context, w *node.ResponseWriter,
 		address := bitcoin.NewAddressFromRawAddress(ct.MovedTo, w.Config.Net)
 		node.LogWarn(ctx, "Contract address changed : %s", address.String())
 		return respondTransferReject(ctx, t.MasterDB, t.Config, w, itx, msg, rk,
-			actions.RejectionsContractMoved, false)
+			actions.RejectionsContractMoved, false, "")
 	}
 
 	if ct.FreezePeriod.Nano() > v.Now.Nano() {
 		node.LogWarn(ctx, "Contract frozen")
 		return respondTransferReject(ctx, t.MasterDB, t.Config, w, itx, msg, rk,
-			actions.RejectionsContractFrozen, false)
+			actions.RejectionsContractFrozen, false, "")
 	}
 
 	if ct.ContractExpiration.Nano() != 0 && ct.ContractExpiration.Nano() < v.Now.Nano() {
 		node.LogWarn(ctx, "Contract expired : %s", ct.ContractExpiration.String())
 		return respondTransferReject(ctx, t.MasterDB, t.Config, w, itx, msg, rk,
-			actions.RejectionsContractExpired, false)
+			actions.RejectionsContractExpired, false, "")
 	}
 
 	// Transfer Outputs
@@ -148,7 +150,7 @@ func (t *Transfer) TransferRequest(ctx context.Context, w *node.ResponseWriter,
 	if err != nil {
 		node.LogWarn(ctx, "Failed to build settlement tx : %s", err)
 		return respondTransferReject(ctx, t.MasterDB, t.Config, w, itx, msg, rk,
-			actions.RejectionsMsgMalformed, false)
+			actions.RejectionsMsgMalformed, false, "")
 	}
 
 	// Update outputs to pay bitcoin receivers.
@@ -156,7 +158,7 @@ func (t *Transfer) TransferRequest(ctx context.Context, w *node.ResponseWriter,
 	if err != nil {
 		node.LogWarn(ctx, "Failed to add bitcoin settlements : %s", err)
 		return respondTransferReject(ctx, t.MasterDB, t.Config, w, itx, msg, rk,
-			actions.RejectionsMsgMalformed, false)
+			actions.RejectionsMsgMalformed, false, "")
 	}
 
 	// Create initial settlement data
@@ -182,7 +184,8 @@ func (t *Transfer) TransferRequest(ctx context.Context, w *node.ResponseWriter,
 		rejectCode, ok := node.ErrorCode(err)
 		if ok {
 			node.LogWarn(ctx, "Rejecting Transfer : %s", err)
-			return respondTransferReject(ctx, t.MasterDB, t.Config, w, itx, msg, rk, rejectCode, false)
+			return respondTransferReject(ctx, t.MasterDB, t.Config, w, itx, msg, rk, rejectCode,
+				false, "")
 		} else {
 			return errors.Wrap(err, "Failed to add settlement data")
 		}
@@ -195,11 +198,11 @@ func (t *Transfer) TransferRequest(ctx context.Context, w *node.ResponseWriter,
 			if txbuilder.IsErrorCode(err, txbuilder.ErrorCodeInsufficientValue) {
 				node.LogWarn(ctx, "Insufficient settlement tx funding : %s", err)
 				return respondTransferReject(ctx, t.MasterDB, t.Config, w, itx, msg, rk,
-					actions.RejectionsInsufficientTxFeeFunding, false)
+					actions.RejectionsInsufficientTxFeeFunding, false, txbuilder.ErrorMessage(err))
 			} else {
 				node.LogWarn(ctx, "Failed to sign settlement tx : %s", err)
 				return respondTransferReject(ctx, t.MasterDB, t.Config, w, itx, msg, rk,
-					actions.RejectionsMsgMalformed, false)
+					actions.RejectionsMsgMalformed, false, "")
 			}
 		}
 
@@ -296,7 +299,8 @@ func (t *Transfer) TransferTimeout(ctx context.Context, w *node.ResponseWriter,
 	}
 
 	node.LogWarn(ctx, "Transfer timed out")
-	return respondTransferReject(ctx, t.MasterDB, t.Config, w, itx, msg, rk, actions.RejectionsTimeout, true)
+	return respondTransferReject(ctx, t.MasterDB, t.Config, w, itx, msg, rk,
+		actions.RejectionsTimeout, true, "")
 }
 
 // firstContractOutputIndex finds the "first" contract. The "first" contract of a transfer is the one
@@ -1149,8 +1153,9 @@ func (t *Transfer) SettlementResponse(ctx context.Context, w *node.ResponseWrite
 // respondTransferReject sends a reject to all parties involved with a transfer request and refunds
 //   any bitcoin involved. This can only be done by the first contract, because they hold the
 //   bitcoin to be distributed.
-func respondTransferReject(ctx context.Context, masterDB *db.DB, config *node.Config, w *node.ResponseWriter,
-	transferTx *inspector.Transaction, transfer *actions.Transfer, rk *wallet.Key, code uint32, removeBoomerang bool) error {
+func respondTransferReject(ctx context.Context, masterDB *db.DB, config *node.Config,
+	w *node.ResponseWriter, transferTx *inspector.Transaction, transfer *actions.Transfer,
+	rk *wallet.Key, code uint32, removeBoomerang bool, text string) error {
 
 	// Determine UTXOs to fund the reject response.
 	utxos, err := transferTx.UTXOs().ForAddress(rk.Address)
@@ -1235,5 +1240,5 @@ func respondTransferReject(ctx context.Context, masterDB *db.DB, config *node.Co
 		w.ClearRejectOutputValues(ct.AdministrationAddress)
 	}
 
-	return node.RespondReject(ctx, w, transferTx, rk, code)
+	return node.RespondRejectText(ctx, w, transferTx, rk, code, text)
 }

--- a/pkg/txbuilder/errors.go
+++ b/pkg/txbuilder/errors.go
@@ -19,6 +19,14 @@ func IsErrorCode(err error, code int) bool {
 	return er.code == code
 }
 
+func ErrorMessage(err error) string {
+	er, ok := err.(*txBuilderError)
+	if !ok {
+		return ""
+	}
+	return er.message
+}
+
 type txBuilderError struct {
 	code    int
 	message string

--- a/pkg/txbuilder/errors.go
+++ b/pkg/txbuilder/errors.go
@@ -8,6 +8,7 @@ const (
 	ErrorCodeMissingPrivateKey   = 3
 	ErrorCodeWrongScriptTemplate = 4
 	ErrorCodeBelowDustValue      = 5
+	ErrorCodeDuplicateInput      = 6
 )
 
 func IsErrorCode(err error, code int) bool {
@@ -40,6 +41,8 @@ func errorCodeString(code int) string {
 		return "Missing Private Key"
 	case ErrorCodeWrongScriptTemplate:
 		return "Wrong Script Template"
+	case ErrorCodeDuplicateInput:
+		return "Duplicate Input"
 	default:
 		return "Unknown Error Code"
 	}

--- a/pkg/txbuilder/fees.go
+++ b/pkg/txbuilder/fees.go
@@ -2,7 +2,6 @@ package txbuilder
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/tokenized/smart-contract/pkg/wire"
 )
@@ -132,11 +131,11 @@ func (tx *TxBuilder) adjustFee(amount int64) (bool, error) {
 	if amount > int64(0) {
 		// Increase fee, transfer from change
 		if changeOutputIndex == 0xffffffff {
-			return false, newError(ErrorCodeInsufficientValue, fmt.Sprintf("No existing change for tx fee"))
+			return false, newError(ErrorCodeInsufficientValue, "No existing change for tx fee")
 		}
 
 		if tx.MsgTx.TxOut[changeOutputIndex].Value < uint64(amount) {
-			return false, newError(ErrorCodeInsufficientValue, fmt.Sprintf("Not enough change for tx fee"))
+			return false, newError(ErrorCodeInsufficientValue, "Not enough change for tx fee")
 		}
 
 		// Decrease change, thereby increasing the fee
@@ -146,7 +145,7 @@ func (tx *TxBuilder) adjustFee(amount int64) (bool, error) {
 		if tx.MsgTx.TxOut[changeOutputIndex].Value < tx.DustLimit {
 			if !tx.Outputs[changeOutputIndex].addedForFee {
 				// Don't remove outputs unless they were added by fee adjustment
-				return false, newError(ErrorCodeInsufficientValue, fmt.Sprintf("Not enough change for tx fee"))
+				return false, newError(ErrorCodeInsufficientValue, "Not enough change for tx fee")
 			}
 			// Remove change output since it is less than dust. Dust will go to miner.
 			tx.MsgTx.TxOut = append(tx.MsgTx.TxOut[:changeOutputIndex], tx.MsgTx.TxOut[changeOutputIndex+1:]...)

--- a/pkg/txbuilder/sign.go
+++ b/pkg/txbuilder/sign.go
@@ -85,6 +85,10 @@ func (tx *TxBuilder) Sign(keys []bitcoin.Key) error {
 	currentFee := int64(inputValue) - int64(outputValue)
 	done, err = tx.adjustFee(estimatedFee - currentFee)
 	if err != nil {
+		if IsErrorCode(err, ErrorCodeInsufficientValue) {
+			return newError(ErrorCodeInsufficientValue, fmt.Sprintf("%d/%d", inputValue,
+				outputValue+uint64(estimatedFee)))
+		}
 		return err
 	}
 
@@ -152,6 +156,10 @@ func (tx *TxBuilder) Sign(keys []bitcoin.Key) error {
 
 		done, err = tx.adjustFee(targetFee - currentFee)
 		if err != nil {
+			if IsErrorCode(err, ErrorCodeInsufficientValue) {
+				return newError(ErrorCodeInsufficientValue, fmt.Sprintf("%d/%d", inputValue,
+					outputValue+uint64(targetFee)))
+			}
 			return err
 		}
 


### PR DESCRIPTION
Add automatic check for duplicate inputs. This makes it easier to add funding after already having added specific UTXOs without having to previously filter out the UTXOs. They will just be automatically skipped.

Add specific contract funding provided and needed in M2 reject message.