### PR TITLE
Filter bug

### DIFF
--- a/cmd/smartcontract/cmd/cmd_convert.go
+++ b/cmd/smartcontract/cmd/cmd_convert.go
@@ -23,6 +23,13 @@ var cmdConvert = &cobra.Command{
 			return nil
 		}
 
+		if len(args[0]) == 66 {
+			hash, _ := hex.DecodeString(args[0])
+			ra, _ := bitcoin.NewRawAddressPKH(bitcoin.Hash160(hash))
+			fmt.Printf("Address : %s\n", bitcoin.NewAddressFromRawAddress(ra, bitcoin.MainNet).String())
+			return nil
+		}
+
 		address, err := bitcoin.DecodeAddress(args[0])
 		if err == nil {
 			h, err := address.Hash()

--- a/cmd/smartcontractd/filters/tx.go
+++ b/cmd/smartcontractd/filters/tx.go
@@ -26,7 +26,7 @@ func NewTxFilter(contractPubKeys [][]byte, tracer *Tracer, isTest bool) *TxFilte
 		pubkeys: contractPubKeys,
 	}
 
-	result.pubkeys = make([][]byte, 0, len(contractPubKeys))
+	result.pkhs = make([][]byte, 0, len(contractPubKeys))
 	for _, pubkey := range contractPubKeys {
 		result.pkhs = append(result.pkhs, bitcoin.Hash160(pubkey))
 	}

--- a/pkg/storage/s3_storage.go
+++ b/pkg/storage/s3_storage.go
@@ -202,10 +202,11 @@ func (s S3Storage) findKeys(ctx context.Context,
 
 	svc := s3.New(s.Session)
 
+	fmt.Printf("Bucket : %s\n", s.Config.Bucket)
+	fmt.Printf("Find keys : %s\n", path)
 	input := &s3.ListObjectsV2Input{
-		Bucket:    aws.String(s.Config.Bucket),
-		Prefix:    &path,
-		Delimiter: aws.String("/"),
+		Bucket: aws.String(s.Config.Bucket),
+		Prefix: &path,
 	}
 
 	out, err := svc.ListObjectsV2(input)


### PR DESCRIPTION
The tx filter was unintentionally clearing pubkeys after initializing them in the constructor. This is a fairly serious bug and since it prevents smart contract from processing txs that only reference the contract address from the inputs, like in settlement transactions.

The delimiter also needed to be removed from the S3 list function so that the smart contract CLI state function could properly list holdings when on S3.