### PR TITLE
Implement multi-contract holding statuses. #17

### DIFF
--- a/cmd/smartcontractd/handlers/asset.go
+++ b/cmd/smartcontractd/handlers/asset.go
@@ -332,7 +332,7 @@ func (a *Asset) ModificationRequest(ctx context.Context, w *node.ResponseWriter,
 		txid := protocol.TxIdFromBytes(itx.Hash[:])
 
 		if ac.TokenQty < as.TokenQty {
-			if err := holdings.AddDebit(h, txid, as.TokenQty-ac.TokenQty, v.Now); err != nil {
+			if err := holdings.AddDebit(h, txid, as.TokenQty-ac.TokenQty, true, v.Now); err != nil {
 				node.LogWarn(ctx, "%s : Failed to reduce administration holdings : %s", v.TraceID, err)
 				if err == holdings.ErrInsufficientHoldings {
 					return node.RespondReject(ctx, w, itx, rk, actions.RejectionsInsufficientQuantity)
@@ -341,7 +341,7 @@ func (a *Asset) ModificationRequest(ctx context.Context, w *node.ResponseWriter,
 				}
 			}
 		} else {
-			if err := holdings.AddDeposit(h, txid, ac.TokenQty-as.TokenQty, v.Now); err != nil {
+			if err := holdings.AddDeposit(h, txid, ac.TokenQty-as.TokenQty, true, v.Now); err != nil {
 				node.LogWarn(ctx, "%s : Failed to increase administration holdings : %s", v.TraceID, err)
 				return errors.Wrap(err, "Failed to increase holdings")
 			}
@@ -482,7 +482,7 @@ func (a *Asset) CreationResponse(ctx context.Context, w *node.ResponseWriter,
 			return errors.Wrap(err, "Failed to get admin holding")
 		}
 		txid := protocol.TxIdFromBytes(itx.Hash[:])
-		holdings.AddDeposit(h, txid, msg.TokenQty, protocol.NewTimestamp(msg.Timestamp))
+		holdings.AddDeposit(h, txid, msg.TokenQty, true, protocol.NewTimestamp(msg.Timestamp))
 		holdings.FinalizeTx(h, txid, msg.TokenQty, protocol.NewTimestamp(msg.Timestamp))
 		cacheItem, err := holdings.Save(ctx, a.MasterDB, rk.Address, assetCode, h)
 		if err != nil {

--- a/cmd/smartcontractd/handlers/enforcement.go
+++ b/cmd/smartcontractd/handlers/enforcement.go
@@ -447,7 +447,7 @@ func (e *Enforcement) OrderConfiscateRequest(ctx context.Context, w *node.Respon
 			return errors.Wrap(err, "Failed to get holding")
 		}
 
-		err = holdings.AddDebit(h, txid, target.Quantity, v.Now)
+		err = holdings.AddDebit(h, txid, target.Quantity, true, v.Now)
 		if err != nil {
 			node.LogWarn(ctx, "Failed confiscation for holding : %x %s : %s", msg.AssetCode,
 				address.String(), err)
@@ -489,7 +489,7 @@ func (e *Enforcement) OrderConfiscateRequest(ctx context.Context, w *node.Respon
 	if err != nil {
 		return errors.Wrap(err, "Failed to get holding")
 	}
-	err = holdings.AddDeposit(depositHolding, txid, depositAmount, v.Now)
+	err = holdings.AddDeposit(depositHolding, txid, depositAmount, true, v.Now)
 	if err != nil {
 		address := bitcoin.NewAddressFromRawAddress(depositAddress,
 			w.Config.Net)
@@ -613,7 +613,7 @@ func (e *Enforcement) OrderReconciliationRequest(ctx context.Context, w *node.Re
 			return errors.Wrap(err, "Failed to get holding")
 		}
 
-		err = holdings.AddDebit(h, txid, target.Quantity, v.Now)
+		err = holdings.AddDebit(h, txid, target.Quantity, true, v.Now)
 		if err != nil {
 			node.LogWarn(ctx, "Failed reconciliation for holding : %x %s : %s", msg.AssetCode,
 				address.String(), err)

--- a/cmd/smartcontractd/handlers/governance.go
+++ b/cmd/smartcontractd/handlers/governance.go
@@ -524,7 +524,6 @@ func (g *Governance) BallotCastRequest(ctx context.Context, w *node.ResponseWrit
 			ct.VotingSystems[proposal.VoteSystem].VoteMultiplierPermitted, v.Now)
 	}
 
-	fmt.Printf("Ballot Quantity %d\n", quantity)
 	if quantity == 0 {
 		address := bitcoin.NewAddressFromRawAddress(itx.Inputs[0].Address,
 			w.Config.Net)

--- a/internal/holdings/storage.go
+++ b/internal/holdings/storage.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/pkg/errors"
 	"github.com/tokenized/smart-contract/internal/platform/db"
 	"github.com/tokenized/smart-contract/internal/platform/state"
 	"github.com/tokenized/smart-contract/pkg/bitcoin"
+
 	"github.com/tokenized/specification/dist/golang/protocol"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/internal/platform/state/models.go
+++ b/internal/platform/state/models.go
@@ -95,6 +95,8 @@ type HoldingStatus struct {
 	SettleQuantity uint64             `json:"SettleQuantity,omitempty"`
 
 	// Balance has been posted to the chain and is not reversible without a reconcile.
+	// Note: This is currently not used as address balances are locked during multi-contract
+	//   transfers so a bad state can never be posted.
 	Posted bool `json:"Posted,omitempty"`
 }
 

--- a/internal/vote/storage.go
+++ b/internal/vote/storage.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tokenized/smart-contract/internal/platform/db"
 	"github.com/tokenized/smart-contract/internal/platform/state"
 	"github.com/tokenized/smart-contract/pkg/bitcoin"
+
 	"github.com/tokenized/specification/dist/golang/protocol"
 )
 

--- a/internal/vote/vote.go
+++ b/internal/vote/vote.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tokenized/smart-contract/internal/platform/state"
 	"github.com/tokenized/smart-contract/pkg/bitcoin"
 	"github.com/tokenized/smart-contract/pkg/logger"
+
 	"github.com/tokenized/specification/dist/golang/actions"
 	"github.com/tokenized/specification/dist/golang/protocol"
 


### PR DESCRIPTION
This fixes the vulnerability of starting a multi-contract transfer, then requesting another transfer on the same address before the multi-contract transfer is complete. Then if the multi-contract transfer fails by another contract, the balance posted in the settlement will be wrong and a reconciliation will be needed.

Now the intermediate request will just be rejected and the holder will have to wait for the original transfer to complete before requesting another transfer on the same address.