### PR TITLE
Shotgun responses

### DIFF
--- a/cmd/smartcontract/client/node.go
+++ b/cmd/smartcontract/client/node.go
@@ -53,6 +53,7 @@ type Config struct {
 		StartHash        string `envconfig:"CLIENT_START_HASH"`
 		UntrustedClients int    `default:"16" envconfig:"CLIENT_UNTRUSTED_NODES"`
 		SafeTxDelay      int    `default:"10" envconfig:"CLIENT_SAFE_TX_DELAY"`
+		ShotgunCount     int    `default:"100" envconfig:"SHOTGUN_COUNT"`
 	}
 }
 
@@ -120,7 +121,8 @@ func (client *Client) setupSpyNode(ctx context.Context) error {
 
 	spyConfig, err := data.NewConfig(client.Config.Net, client.Config.SpyNode.Address,
 		client.Config.SpyNode.UserAgent, client.Config.SpyNode.StartHash,
-		client.Config.SpyNode.UntrustedClients, client.Config.SpyNode.SafeTxDelay)
+		client.Config.SpyNode.UntrustedClients, client.Config.SpyNode.SafeTxDelay,
+		client.Config.SpyNode.ShotgunCount)
 	if err != nil {
 		logger.Warn(ctx, "Failed to create spynode config : %s", err)
 		return err

--- a/cmd/smartcontract/cmd/cmd_build.go
+++ b/cmd/smartcontract/cmd/cmd_build.go
@@ -218,7 +218,7 @@ func buildAction(c *cobra.Command, args []string) error {
 			}
 			fmt.Printf("%x\n", buf.Bytes())
 		} else {
-			fmt.Println(tx.MsgTx.String())
+			fmt.Println(tx.MsgTx.StringWithAddresses(network(c)))
 		}
 
 		send, _ := c.Flags().GetBool(FlagSend)

--- a/cmd/smartcontract/cmd/cmd_parse.go
+++ b/cmd/smartcontract/cmd/cmd_parse.go
@@ -70,7 +70,7 @@ func parseTx(c *cobra.Command, rawtx []byte) error {
 	}
 
 	fmt.Printf("\nTx (%d bytes) : %s\n", tx.SerializeSize(), tx.TxHash().String())
-	dumpJSON(tx)
+	fmt.Printf(tx.StringWithAddresses(network(c)))
 
 	for _, txOut := range tx.TxOut {
 		if parseScript(c, txOut.PkScript) == nil {

--- a/cmd/smartcontractd/main.go
+++ b/cmd/smartcontractd/main.go
@@ -84,7 +84,8 @@ func main() {
 	}
 
 	spyConfig, err := data.NewConfig(appConfig.Net, cfg.SpyNode.Address, cfg.SpyNode.UserAgent,
-		cfg.SpyNode.StartHash, cfg.SpyNode.UntrustedNodes, cfg.SpyNode.SafeTxDelay)
+		cfg.SpyNode.StartHash, cfg.SpyNode.UntrustedNodes, cfg.SpyNode.SafeTxDelay,
+		cfg.SpyNode.ShotgunCount)
 	if err != nil {
 		logger.Fatal(ctx, "Failed to create spynode config : %s", err)
 		return

--- a/cmd/smartcontractd/tests/contract_test.go
+++ b/cmd/smartcontractd/tests/contract_test.go
@@ -358,8 +358,14 @@ func oracleContract(t *testing.T) {
 		t.Fatalf("\t%s\tContract offer handle state failed : %v", tests.Failed, err)
 	}
 
+	var firstResponse *wire.MsgTx // Request tx is re-broadcast now
 	var response *wire.MsgTx
 	for {
+		if firstResponse == nil {
+			firstResponse = getResponse()
+			time.Sleep(time.Millisecond)
+			continue
+		}
 		response = getResponse()
 		if response != nil {
 			break
@@ -420,7 +426,13 @@ func oracleContract(t *testing.T) {
 		t.Fatalf("\t%s\tContract offer handle state failed : %v", tests.Failed, err)
 	}
 
+	firstResponse = nil // Request is re-broadcast
 	for {
+		if firstResponse == nil {
+			firstResponse = getResponse()
+			time.Sleep(time.Millisecond)
+			continue
+		}
 		response = getResponse()
 		if response != nil {
 			break

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 		StartHash      string `envconfig:"START_HASH"`
 		UntrustedNodes int    `default:"8" envconfig:"UNTRUSTED_NODES"`
 		SafeTxDelay    int    `default:"2000" envconfig:"SAFE_TX_DELAY"`
+		ShotgunCount   int    `default:"100" envconfig:"SHOTGUN_COUNT"`
 	}
 	RpcNode struct {
 		Host     string `envconfig:"RPC_HOST"`

--- a/pkg/spynode/cmd/spynoded/main.go
+++ b/pkg/spynode/cmd/spynoded/main.go
@@ -50,6 +50,7 @@ func main() {
 			StartHash      string `envconfig:"START_HASH"`
 			UntrustedNodes int    `default:"8" envconfig:"UNTRUSTED_NODES"`
 			SafeTxDelay    int    `default:"2000" envconfig:"SAFE_TX_DELAY"`
+			ShotgunCount   int    `default:"100" envconfig:"SHOTGUN_COUNT"`
 		}
 		NodeStorage struct {
 			Region    string `default:"ap-southeast-2" envconfig:"NODE_STORAGE_REGION"`
@@ -94,8 +95,9 @@ func main() {
 
 	// -------------------------------------------------------------------------
 	// Node Config
-	nodeConfig, err := data.NewConfig(bitcoin.NetworkFromString(cfg.Network), cfg.Node.Address, cfg.Node.UserAgent,
-		cfg.Node.StartHash, cfg.Node.UntrustedNodes, cfg.Node.SafeTxDelay)
+	nodeConfig, err := data.NewConfig(bitcoin.NetworkFromString(cfg.Network), cfg.Node.Address,
+		cfg.Node.UserAgent, cfg.Node.StartHash, cfg.Node.UntrustedNodes, cfg.Node.SafeTxDelay,
+		cfg.Node.ShotgunCount)
 	if err != nil {
 		logger.Error(ctx, "Failed to create node config : %s\n", err)
 		return

--- a/pkg/spynode/handlers/handlers_test.go
+++ b/pkg/spynode/handlers/handlers_test.go
@@ -63,7 +63,7 @@ func TestHandlers(test *testing.T) {
 
 	// Setup config
 	startHash, err := bitcoin.NewHash32FromStr("0000000000000000000000000000000000000000000000000000000000000000")
-	config, err := data.NewConfig(bitcoin.MainNet, "test", "Tokenized Test", startHash.String(), 8, 2000)
+	config, err := data.NewConfig(bitcoin.MainNet, "test", "Tokenized Test", startHash.String(), 8, 2000, 10)
 	if err != nil {
 		test.Errorf("Failed to create config : %v", err)
 	}

--- a/pkg/spynode/handlers/storage/blocks_test.go
+++ b/pkg/spynode/handlers/storage/blocks_test.go
@@ -23,7 +23,7 @@ func TestBlocks(test *testing.T) {
 
 	// Setup config
 	startHash, err := bitcoin.NewHash32FromStr("0000000000000000000000000000000000000000000000000000000000000000")
-	config, err := data.NewConfig(bitcoin.MainNet, "test", "Tokenized Test", startHash.String(), 8, 2000)
+	config, err := data.NewConfig(bitcoin.MainNet, "test", "Tokenized Test", startHash.String(), 8, 2000, 10)
 	if err != nil {
 		test.Errorf("Failed to create config : %v", err)
 	}

--- a/pkg/wire/msgtx.go
+++ b/pkg/wire/msgtx.go
@@ -314,6 +314,43 @@ func (msg *MsgTx) String() string {
 	return result
 }
 
+func (msg *MsgTx) StringWithAddresses(net bitcoin.Network) string {
+	result := fmt.Sprintf("TxId: %s\n", msg.TxHash().String())
+	result += fmt.Sprintf("  Version: %d\n", msg.Version)
+	result += "  Inputs:\n\n"
+	for _, input := range msg.TxIn {
+		result += fmt.Sprintf("    Outpoint: %d - %s\n", input.PreviousOutPoint.Index,
+			input.PreviousOutPoint.Hash.String())
+		result += fmt.Sprintf("    Script: %x\n", input.SignatureScript)
+		result += fmt.Sprintf("    Sequence: %x\n", input.Sequence)
+
+		// Address
+		ra, err := bitcoin.RawAddressFromUnlockingScript(input.SignatureScript)
+		if err == nil {
+			ad := bitcoin.NewAddressFromRawAddress(ra, net)
+			result += fmt.Sprintf("    Address: %s\n", ad.String())
+		}
+
+		result += "\n"
+	}
+	result += "  Outputs:\n\n"
+	for _, output := range msg.TxOut {
+		result += fmt.Sprintf("    Value: %.08f\n", float32(output.Value)/100000000.0)
+		result += fmt.Sprintf("    Script: %x\n", output.PkScript)
+
+		// Address
+		ra, err := bitcoin.RawAddressFromLockingScript(output.PkScript)
+		if err == nil {
+			ad := bitcoin.NewAddressFromRawAddress(ra, net)
+			result += fmt.Sprintf("    Address: %s\n", ad.String())
+		}
+
+		result += "\n"
+	}
+	result += fmt.Sprintf("  LockTime: %d\n", msg.LockTime)
+	return result
+}
+
 // Copy creates a deep copy of a transaction so that the original does not get
 // modified when the copy is manipulated.
 func (msg *MsgTx) Copy() *MsgTx {


### PR DESCRIPTION
Implement shotgunning of incoming/request transaction to ensure most of the network has seen it.
Implement shotgunning of response transactions to a configurable number of nodes rather than just the nodes already connected to.
Add a new msgtx string function that has addresses.