### PR TITLE
Key Overhaul and Oracle Fixes

### DIFF
--- a/cmd/smartcontract/client/wallet.go
+++ b/cmd/smartcontract/client/wallet.go
@@ -122,7 +122,7 @@ func (wallet *Wallet) RemoveUTXO(txid *bitcoin.Hash32, index uint32, script []by
 func (wallet *Wallet) Load(ctx context.Context, wifKey, path string, net bitcoin.Network) error {
 	// Private Key
 	var err error
-	wallet.Key, err = bitcoin.DecodeKeyString(wifKey)
+	wallet.Key, err = bitcoin.KeyFromStr(wifKey)
 	if err != nil {
 		return err
 	}

--- a/cmd/smartcontract/cmd/cmd_convert.go
+++ b/cmd/smartcontract/cmd/cmd_convert.go
@@ -23,6 +23,14 @@ var cmdConvert = &cobra.Command{
 			return nil
 		}
 
+		key, err := bitcoin.KeyFromStr(args[0])
+		if err == nil {
+			fmt.Printf("PublicKey : %s\n", key.PublicKey().String())
+			ra, _ := key.RawAddress()
+			fmt.Printf("Address : %s\n", bitcoin.NewAddressFromRawAddress(ra, bitcoin.MainNet).String())
+			return nil
+		}
+
 		if len(args[0]) == 66 {
 			hash, _ := hex.DecodeString(args[0])
 			ra, _ := bitcoin.NewRawAddressPKH(bitcoin.Hash160(hash))

--- a/cmd/smartcontract/cmd/cmd_gen.go
+++ b/cmd/smartcontract/cmd/cmd_gen.go
@@ -24,7 +24,7 @@ var cmdGen = &cobra.Command{
 			return nil
 		}
 
-		key, err := bitcoin.GenerateKeyS256(network)
+		key, err := bitcoin.GenerateKey(network)
 		if err != nil {
 			fmt.Printf("Failed to generate key : %s\n", err)
 			return nil

--- a/cmd/smartcontract/cmd/cmd_gen.go
+++ b/cmd/smartcontract/cmd/cmd_gen.go
@@ -10,12 +10,43 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	FlagX  = "x"
+	FlagXs = "xs"
+)
+
 var cmdGen = &cobra.Command{
 	Use:   "gen",
 	Short: "Generates a bitcoin private key in WIF",
 	RunE: func(c *cobra.Command, args []string) error {
 		if len(args) != 0 {
 			return errors.New("Incorrect argument count")
+		}
+
+		extended, _ := c.Flags().GetBool(FlagX)
+		if extended {
+			key, err := bitcoin.GenerateMasterExtendedKey()
+			if err != nil {
+				fmt.Printf("Failed to generate extended key : %s\n", err)
+				return nil
+			}
+
+			fmt.Printf("XKey : %s\n", key.String())
+			return nil
+		}
+
+		extendedMulti, _ := c.Flags().GetBool(FlagXs)
+		if extendedMulti {
+			key, err := bitcoin.GenerateMasterExtendedKey()
+			if err != nil {
+				fmt.Printf("Failed to generate extended key : %s\n", err)
+				return nil
+			}
+
+			keys := bitcoin.ExtendedKeys{key}
+
+			fmt.Printf("XKeys : %s\n", keys.String())
+			return nil
 		}
 
 		network := network(c)
@@ -44,4 +75,6 @@ var cmdGen = &cobra.Command{
 }
 
 func init() {
+	cmdGen.Flags().Bool(FlagX, false, "generate an extended key")
+	cmdGen.Flags().Bool(FlagXs, false, "generate an multi-extended key")
 }

--- a/cmd/smartcontract/cmd/cmd_sign.go
+++ b/cmd/smartcontract/cmd/cmd_sign.go
@@ -88,7 +88,7 @@ func transferSign(c *cobra.Command, args []string) error {
 		return nil
 	}
 
-	key, err := bitcoin.DecodeKeyString(args[4])
+	key, err := bitcoin.KeyFromStr(args[4])
 	if err != nil {
 		fmt.Printf("Invalid key : %s\n", err)
 		return nil

--- a/cmd/smartcontract/cmd/cmd_sign.go
+++ b/cmd/smartcontract/cmd/cmd_sign.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -52,7 +51,6 @@ func transferSign(c *cobra.Command, args []string) error {
 	}
 
 	// Contract key
-	hash := make([]byte, 20)
 	contractAddress, err := bitcoin.DecodeAddress(args[1])
 	if err != nil {
 		fmt.Printf("Invalid contract address : %s\n", err)
@@ -67,22 +65,7 @@ func transferSign(c *cobra.Command, args []string) error {
 	}
 
 	// Block hash
-	hash = make([]byte, 32)
-	n, err := hex.Decode(hash, []byte(args[3]))
-	if err != nil {
-		fmt.Printf("Failed to parse block hash : %s\n", err)
-		return nil
-	}
-	if n != 32 {
-		fmt.Printf("Invalid block hash size : %d\n", n)
-		return nil
-	}
-	// Reverse hash (make little endian)
-	reverseHash := make([]byte, 32)
-	for i, b := range hash {
-		reverseHash[31-i] = b
-	}
-	blockHash, err := bitcoin.NewHash32(reverseHash)
+	blockHash, err := bitcoin.NewHash32FromStr(args[3])
 	if err != nil {
 		fmt.Printf("Invalid block hash : %s\n", err)
 		return nil
@@ -125,7 +108,7 @@ func transferSign(c *cobra.Command, args []string) error {
 					return nil
 				}
 
-				fmt.Printf("Signature : %x\n", signature)
+				fmt.Printf("Signature : %x\n", signature.Bytes())
 				return nil
 			}
 

--- a/cmd/smartcontractd/filters/tx.go
+++ b/cmd/smartcontractd/filters/tx.go
@@ -19,19 +19,11 @@ type TxFilter struct {
 	lock    sync.RWMutex
 }
 
-func NewTxFilter(contractPubKeys [][]byte, tracer *Tracer, isTest bool) *TxFilter {
-	result := TxFilter{
-		tracer:  tracer,
-		isTest:  isTest,
-		pubkeys: contractPubKeys,
+func NewTxFilter(tracer *Tracer, isTest bool) *TxFilter {
+	return &TxFilter{
+		tracer: tracer,
+		isTest: isTest,
 	}
-
-	result.pkhs = make([][]byte, 0, len(contractPubKeys))
-	for _, pubkey := range contractPubKeys {
-		result.pkhs = append(result.pkhs, bitcoin.Hash160(pubkey))
-	}
-
-	return &result
 }
 
 func (filter *TxFilter) AddPubKey(ctx context.Context, contractPubKey []byte) {

--- a/cmd/smartcontractd/handlers/contract.go
+++ b/cmd/smartcontractd/handlers/contract.go
@@ -858,13 +858,13 @@ func applyContractAmendments(cf *actions.ContractFormation, amendments []*action
 func validateContractAmendOracleSig(ctx context.Context, updatedContract *state.Contract,
 	headers node.BitcoinHeaders) error {
 
-	oracle, err := bitcoin.DecodePublicKeyBytes(updatedContract.AdminOracle.PublicKey)
+	oracle, err := bitcoin.PublicKeyFromBytes(updatedContract.AdminOracle.PublicKey)
 	if err != nil {
 		return err
 	}
 
 	// Parse signature
-	oracleSig, err := bitcoin.DecodeSignatureBytes(updatedContract.AdminOracleSignature)
+	oracleSig, err := bitcoin.SignatureFromBytes(updatedContract.AdminOracleSignature)
 	if err != nil {
 		return errors.Wrap(err, "Failed to parse oracle signature")
 	}

--- a/cmd/smartcontractd/handlers/enforcement.go
+++ b/cmd/smartcontractd/handlers/enforcement.go
@@ -78,13 +78,13 @@ func (e *Enforcement) OrderRequest(ctx context.Context, w *node.ResponseWriter,
 			return node.RespondReject(ctx, w, itx, rk, actions.RejectionsMsgMalformed)
 		}
 
-		authorityPubKey, err := bitcoin.DecodePublicKeyBytes(msg.AuthorityPublicKey)
+		authorityPubKey, err := bitcoin.PublicKeyFromBytes(msg.AuthorityPublicKey)
 		if err != nil {
 			node.LogWarn(ctx, "Failed to parse authority pub key : %s", err)
 			return node.RespondReject(ctx, w, itx, rk, actions.RejectionsMsgMalformed)
 		}
 
-		authoritySig, err := bitcoin.DecodeSignatureBytes(msg.OrderSignature)
+		authoritySig, err := bitcoin.SignatureFromBytes(msg.OrderSignature)
 		if err != nil {
 			node.LogWarn(ctx, "Failed to parse authority signature : %s", err)
 			return node.RespondReject(ctx, w, itx, rk, actions.RejectionsMsgMalformed)

--- a/cmd/smartcontractd/handlers/transfer.go
+++ b/cmd/smartcontractd/handlers/transfer.go
@@ -72,14 +72,9 @@ func (t *Transfer) TransferRequest(ctx context.Context, w *node.ResponseWriter,
 		return nil // Wait for M1 - 1001 requesting data to complete Settlement tx.
 	}
 
-	if itx.RejectCode != 0 {
-		node.LogWarn(ctx, "Transfer request invalid")
-		return respondTransferReject(ctx, t.MasterDB, t.HoldingsChannel, t.Config, w, itx, msg, rk,
-			itx.RejectCode, false, "")
-	}
-
 	// Check pre-processing reject code
 	if itx.RejectCode != 0 {
+		node.LogWarn(ctx, "Transfer request invalid")
 		return respondTransferReject(ctx, t.MasterDB, t.HoldingsChannel, t.Config, w, itx, msg, rk,
 			itx.RejectCode, false, "")
 	}

--- a/cmd/smartcontractd/listeners/incoming.go
+++ b/cmd/smartcontractd/listeners/incoming.go
@@ -123,8 +123,10 @@ func (server *Server) MarkSafe(ctx context.Context, txid *bitcoin.Hash32) {
 	}
 
 	// Broadcast to ensure it is accepted by the network.
-	if err := server.sendTx(ctx, intx.Itx.MsgTx); err != nil {
-		node.LogWarn(ctx, "Failed to re-broadcast safe incoming : %s", err)
+	if server.inSync {
+		if err := server.sendTx(ctx, intx.Itx.MsgTx); err != nil {
+			node.LogWarn(ctx, "Failed to re-broadcast safe incoming : %s", err)
+		}
 	}
 
 	intx.IsReady = true
@@ -182,11 +184,6 @@ func (server *Server) MarkConfirmed(ctx context.Context, txid *bitcoin.Hash32) {
 	intx, exists := server.pendingTxs[*txid]
 	if !exists {
 		return
-	}
-
-	// Broadcast to ensure it is accepted by the network.
-	if err := server.sendTx(ctx, intx.Itx.MsgTx); err != nil {
-		node.LogWarn(ctx, "Failed to re-broadcast confirmed incoming : %s", err)
 	}
 
 	intx.IsReady = true

--- a/cmd/smartcontractd/listeners/incoming.go
+++ b/cmd/smartcontractd/listeners/incoming.go
@@ -303,7 +303,7 @@ func validateOracle(ctx context.Context, contractAddress bitcoin.RawAddress, ct 
 	}
 
 	// Parse signature
-	oracleSig, err := bitcoin.DecodeSignatureBytes(assetReceiver.OracleConfirmationSig)
+	oracleSig, err := bitcoin.SignatureFromBytes(assetReceiver.OracleConfirmationSig)
 	if err != nil {
 		return errors.Wrap(err, "Failed to parse oracle signature")
 	}
@@ -354,13 +354,13 @@ func validateContractOracleSig(ctx context.Context, itx *inspector.Transaction,
 		return nil
 	}
 
-	oracle, err := bitcoin.DecodePublicKeyBytes(contractOffer.AdminOracle.PublicKey)
+	oracle, err := bitcoin.PublicKeyFromBytes(contractOffer.AdminOracle.PublicKey)
 	if err != nil {
 		return err
 	}
 
 	// Parse signature
-	oracleSig, err := bitcoin.DecodeSignatureBytes(contractOffer.AdminOracleSignature)
+	oracleSig, err := bitcoin.SignatureFromBytes(contractOffer.AdminOracleSignature)
 	if err != nil {
 		return errors.Wrap(err, "Failed to parse oracle signature")
 	}

--- a/cmd/smartcontractd/listeners/incoming.go
+++ b/cmd/smartcontractd/listeners/incoming.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/tokenized/smart-contract/internal/contract"
 	"github.com/tokenized/smart-contract/internal/platform/db"
@@ -308,10 +309,9 @@ func validateOracle(ctx context.Context, contractAddress bitcoin.RawAddress, ct 
 		return errors.Wrap(err, "Failed to parse oracle signature")
 	}
 
-	v := ctx.Value(node.KeyValues).(*node.Values)
-
 	// Check if block time is beyond expiration
-	expire := (v.Now.Seconds()) - 3600 // Hour ago, unix timestamp in seconds
+	// TODO Figure out how to get tx time to here. node.KeyValues is not set in context.
+	expire := uint32((time.Now().Unix())) - 3600 // Hour ago, unix timestamp in seconds
 	blockTime, err := headers.Time(ctx, int(assetReceiver.OracleSigBlockHeight))
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Failed to retrieve time for block height %d",

--- a/cmd/smartcontractd/listeners/incoming.go
+++ b/cmd/smartcontractd/listeners/incoming.go
@@ -342,6 +342,7 @@ func validateOracle(ctx context.Context, contractAddress bitcoin.RawAddress, ct 
 	}
 
 	if oracleSig.Verify(sigHash, oracle) {
+		node.Log(ctx, "Receiver oracle signature is valid")
 		return nil // Valid signature found
 	}
 
@@ -388,6 +389,7 @@ func validateContractOracleSig(ctx context.Context, itx *inspector.Transaction,
 	}
 
 	if oracleSig.Verify(sigHash, oracle) {
+		node.Log(ctx, "Contract oracle signature is valid")
 		return nil // Valid signature found
 	}
 

--- a/cmd/smartcontractd/listeners/listener.go
+++ b/cmd/smartcontractd/listeners/listener.go
@@ -123,6 +123,8 @@ func (server *Server) HandleInSync(ctx context.Context) error {
 
 	ctx = node.ContextWithOutLogSubSystem(ctx)
 	node.Log(ctx, "Node is in sync")
+	node.Log(ctx, "Processing pending : %d responses, %d requests", len(server.pendingResponses),
+		len(server.pendingRequests))
 	server.inSync = true
 	pendingResponses := server.pendingResponses
 	server.pendingResponses = nil

--- a/cmd/smartcontractd/listeners/node.go
+++ b/cmd/smartcontractd/listeners/node.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/tokenized/smart-contract/cmd/smartcontractd/filters"
-	"github.com/tokenized/smart-contract/internal/contract"
 	"github.com/tokenized/smart-contract/internal/holdings"
 	"github.com/tokenized/smart-contract/internal/platform/db"
 	"github.com/tokenized/smart-contract/internal/platform/node"
@@ -19,6 +18,10 @@ import (
 	"github.com/tokenized/smart-contract/pkg/wire"
 
 	"github.com/pkg/errors"
+)
+
+const (
+	walletKey = "wallet" // storage path for wallet
 )
 
 type Server struct {
@@ -218,10 +221,6 @@ func (server *Server) Run(ctx context.Context) error {
 	// Block until goroutines finish as a result of Stop()
 	wg.Wait()
 
-	if err := server.wallet.Save(ctx, server.MasterDB, server.Config.Net); err != nil {
-		return err
-	}
-
 	return server.Tracer.Save(ctx, server.MasterDB)
 }
 
@@ -313,68 +312,4 @@ func (server *Server) revertTx(ctx context.Context, itx *inspector.Transaction) 
 
 func (server *Server) ReprocessTx(ctx context.Context, itx *inspector.Transaction) error {
 	return server.Handler.Trigger(ctx, "END", itx)
-}
-
-// AddContractKey adds a new contract key to those being monitored.
-func (server *Server) AddContractKey(ctx context.Context, k bitcoin.Key) error {
-	server.walletLock.Lock()
-	defer server.walletLock.Unlock()
-
-	rawAddress, err := bitcoin.NewRawAddressPKH(bitcoin.Hash160(k.PublicKey().Bytes()))
-	if err != nil {
-		return err
-	}
-	newKey := wallet.Key{
-		Address: rawAddress,
-		Key:     k,
-	}
-
-	address, _ := bitcoin.NewAddressPKH(bitcoin.Hash160(k.PublicKey().Bytes()), k.Network())
-	node.Log(ctx, "Adding key : %s", address.String())
-	server.wallet.Add(&newKey)
-	if err := server.wallet.Save(ctx, server.MasterDB, server.Config.Net); err != nil {
-		return err
-	}
-	server.contractAddresses = append(server.contractAddresses, rawAddress)
-
-	server.txFilter.AddPubKey(ctx, k.PublicKey().Bytes())
-	return nil
-}
-
-// RemoveContractKeyIfUnused removes a contract key from those being monitored if it hasn't been used yet.
-func (server *Server) RemoveContractKeyIfUnused(ctx context.Context, k bitcoin.Key) error {
-	server.walletLock.Lock()
-	defer server.walletLock.Unlock()
-
-	rawAddress, err := bitcoin.NewRawAddressPKH(bitcoin.Hash160(k.PublicKey().Bytes()))
-	if err != nil {
-		return err
-	}
-	newKey := wallet.Key{
-		Address: rawAddress,
-		Key:     k,
-	}
-
-	// Check if contract exists
-	_, err = contract.Retrieve(ctx, server.MasterDB, rawAddress)
-	if err != contract.ErrNotFound {
-		return nil
-	}
-
-	stringAddress := bitcoin.NewAddressFromRawAddress(rawAddress, server.Config.Net)
-	node.Log(ctx, "Removing key : %s", stringAddress.String())
-	server.wallet.Remove(&newKey)
-	if err := server.wallet.Save(ctx, server.MasterDB, server.Config.Net); err != nil {
-		return err
-	}
-
-	for i, caddress := range server.contractAddresses {
-		if rawAddress.Equal(caddress) {
-			server.contractAddresses = append(server.contractAddresses[:i], server.contractAddresses[i+1:]...)
-			break
-		}
-	}
-
-	server.txFilter.RemovePubKey(ctx, k.PublicKey().Bytes())
-	return nil
 }

--- a/cmd/smartcontractd/listeners/node.go
+++ b/cmd/smartcontractd/listeners/node.go
@@ -97,16 +97,6 @@ func NewServer(
 		holdingsChannel:  holdingsChannel,
 	}
 
-	keys := wallet.ListAll()
-	result.contractAddresses = make([]bitcoin.RawAddress, 0, len(keys))
-	for _, key := range keys {
-		address, err := bitcoin.NewRawAddressPKH(bitcoin.Hash160(key.Key.PublicKey().Bytes()))
-		if err != nil {
-			return nil
-		}
-		result.contractAddresses = append(result.contractAddresses, address)
-	}
-
 	return &result
 }
 

--- a/cmd/smartcontractd/listeners/wallet.go
+++ b/cmd/smartcontractd/listeners/wallet.go
@@ -51,10 +51,12 @@ func (server *Server) RemoveContractKeyIfUnused(ctx context.Context, k bitcoin.K
 
 	// Check if contract exists
 	_, err = contract.Retrieve(ctx, server.MasterDB, rawAddress)
-	if err != nil {
-		if err != contract.ErrNotFound {
-			node.LogWarn(ctx, "Retrieving contract : %s", err)
-		}
+	if err == nil {
+		node.LogWarn(ctx, "Contract found")
+		return nil // Don't remove contract key
+	}
+	if err != contract.ErrNotFound {
+		node.LogWarn(ctx, "Error retrieving contract : %s", err)
 		return nil // Don't remove contract key
 	}
 

--- a/cmd/smartcontractd/listeners/wallet.go
+++ b/cmd/smartcontractd/listeners/wallet.go
@@ -104,5 +104,23 @@ func (server *Server) LoadWallet(ctx context.Context) error {
 		return errors.Wrap(err, "deserialize wallet")
 	}
 
+	return server.SyncWallet(ctx)
+}
+
+func (server *Server) SyncWallet(ctx context.Context) error {
+	node.Log(ctx, "Syncing wallet")
+
+	// Refresh node for wallet.
+	keys := server.wallet.ListAll()
+
+	server.contractAddresses = make([]bitcoin.RawAddress, 0, len(keys))
+	for _, key := range keys {
+		// Contract address
+		server.contractAddresses = append(server.contractAddresses, key.Address)
+
+		// Tx Filter
+		server.txFilter.AddPubKey(ctx, key.Key.PublicKey().Bytes())
+	}
+
 	return nil
 }

--- a/cmd/smartcontractd/listeners/wallet.go
+++ b/cmd/smartcontractd/listeners/wallet.go
@@ -1,0 +1,108 @@
+package listeners
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/tokenized/smart-contract/internal/contract"
+	"github.com/tokenized/smart-contract/internal/platform/db"
+	"github.com/tokenized/smart-contract/internal/platform/node"
+	"github.com/tokenized/smart-contract/pkg/bitcoin"
+	"github.com/tokenized/smart-contract/pkg/wallet"
+
+	"github.com/pkg/errors"
+)
+
+// AddContractKey adds a new contract key to those being monitored.
+func (server *Server) AddContractKey(ctx context.Context, key *wallet.Key) error {
+	server.walletLock.Lock()
+	defer server.walletLock.Unlock()
+
+	rawAddress, err := bitcoin.NewRawAddressPKH(bitcoin.Hash160(key.Key.PublicKey().Bytes()))
+	if err != nil {
+		return err
+	}
+
+	address, _ := bitcoin.NewAddressPKH(bitcoin.Hash160(key.Key.PublicKey().Bytes()),
+		server.Config.Net)
+	node.Log(ctx, "Adding key : %s", address.String())
+	if err := server.SaveWallet(ctx); err != nil {
+		return err
+	}
+	server.contractAddresses = append(server.contractAddresses, rawAddress)
+
+	server.txFilter.AddPubKey(ctx, key.Key.PublicKey().Bytes())
+	return nil
+}
+
+// RemoveContractKeyIfUnused removes a contract key from those being monitored if it hasn't been used yet.
+func (server *Server) RemoveContractKeyIfUnused(ctx context.Context, k bitcoin.Key) error {
+	server.walletLock.Lock()
+	defer server.walletLock.Unlock()
+
+	rawAddress, err := bitcoin.NewRawAddressPKH(bitcoin.Hash160(k.PublicKey().Bytes()))
+	if err != nil {
+		return err
+	}
+	newKey := wallet.Key{
+		Address: rawAddress,
+		Key:     k,
+	}
+
+	// Check if contract exists
+	_, err = contract.Retrieve(ctx, server.MasterDB, rawAddress)
+	if err != nil {
+		if err != contract.ErrNotFound {
+			node.LogWarn(ctx, "Retrieving contract : %s", err)
+		}
+		return nil // Don't remove contract key
+	}
+
+	stringAddress := bitcoin.NewAddressFromRawAddress(rawAddress, server.Config.Net)
+	node.Log(ctx, "Removing key : %s", stringAddress.String())
+	server.wallet.Remove(&newKey)
+	if err := server.SaveWallet(ctx); err != nil {
+		return err
+	}
+
+	for i, caddress := range server.contractAddresses {
+		if rawAddress.Equal(caddress) {
+			server.contractAddresses = append(server.contractAddresses[:i], server.contractAddresses[i+1:]...)
+			break
+		}
+	}
+
+	server.txFilter.RemovePubKey(ctx, k.PublicKey().Bytes())
+	return nil
+}
+
+func (server *Server) SaveWallet(ctx context.Context) error {
+	node.Log(ctx, "Saving wallet")
+	var buf bytes.Buffer
+
+	if err := server.wallet.Serialize(&buf); err != nil {
+		return errors.Wrap(err, "serialize wallet")
+	}
+
+	return server.MasterDB.Put(ctx, walletKey, buf.Bytes())
+}
+
+func (server *Server) LoadWallet(ctx context.Context) error {
+	node.Log(ctx, "Loading wallet")
+
+	data, err := server.MasterDB.Fetch(ctx, walletKey)
+	if err != nil {
+		if err == db.ErrNotFound {
+			return nil // No keys yet
+		}
+		return errors.Wrap(err, "fetch wallet")
+	}
+
+	buf := bytes.NewReader(data)
+
+	if err := server.wallet.Deserialize(buf); err != nil {
+		return errors.Wrap(err, "deserialize wallet")
+	}
+
+	return nil
+}

--- a/cmd/smartcontractd/main.go
+++ b/cmd/smartcontractd/main.go
@@ -121,13 +121,8 @@ func main() {
 	// -------------------------------------------------------------------------
 	// Tx Filter
 
-	walletKeys := masterWallet.ListAll()
-	pubKeys := make([][]byte, 0, len(walletKeys))
-	for _, walletKey := range walletKeys {
-		pubKeys = append(pubKeys, walletKey.Key.PublicKey().Bytes())
-	}
 	tracer := filters.NewTracer()
-	txFilter := filters.NewTxFilter(pubKeys, tracer, appConfig.IsTest)
+	txFilter := filters.NewTxFilter(tracer, appConfig.IsTest)
 	spyNode.AddTxFilter(txFilter)
 
 	// -------------------------------------------------------------------------
@@ -177,6 +172,10 @@ func main() {
 		txFilter,
 		holdingsChannel,
 	)
+
+	if err := node.SyncWallet(ctx); err != nil {
+		logger.Fatal(ctx, "Load Wallet : %s", err)
+	}
 
 	// -------------------------------------------------------------------------
 	// Start Node Service

--- a/cmd/smartcontractd/tests/contract_test.go
+++ b/cmd/smartcontractd/tests/contract_test.go
@@ -322,18 +322,17 @@ func oracleContract(t *testing.T) {
 	test.NodeConfig.PreprocessThreads = 4
 
 	tracer := filters.NewTracer()
-	walletKeys := test.Wallet.ListAll()
-	pubKeys := make([][]byte, 0, len(walletKeys))
 	holdingsChannel := &holdings.CacheChannel{}
-	for _, walletKey := range walletKeys {
-		pubKeys = append(pubKeys, walletKey.Key.PublicKey().Bytes())
-	}
-	txFilter := filters.NewTxFilter(pubKeys, tracer, true)
+	txFilter := filters.NewTxFilter(tracer, true)
 	test.Scheduler = &scheduler.Scheduler{}
 
 	server := listeners.NewServer(test.Wallet, a, &test.NodeConfig, test.MasterDB,
 		test.RPCNode, nil, test.Headers, test.Scheduler, tracer, test.UTXOs, txFilter,
 		holdingsChannel)
+
+	if err := server.SyncWallet(ctx); err != nil {
+		t.Fatalf("Failed to load wallet : %s", err)
+	}
 
 	server.SetAlternateResponder(respondTx)
 	server.SetInSync()

--- a/cmd/smartcontractd/tests/transfer_test.go
+++ b/cmd/smartcontractd/tests/transfer_test.go
@@ -124,17 +124,16 @@ func simpleTransfersBenchmark(b *testing.B) {
 	test.NodeConfig.PreprocessThreads = 4
 
 	tracer := filters.NewTracer()
-	walletKeys := test.Wallet.ListAll()
-	pubKeys := make([][]byte, 0, len(walletKeys))
-	for _, walletKey := range walletKeys {
-		pubKeys = append(pubKeys, walletKey.Key.PublicKey().Bytes())
-	}
-	txFilter := filters.NewTxFilter(pubKeys, tracer, true)
+	txFilter := filters.NewTxFilter(tracer, true)
 	test.Scheduler = &scheduler.Scheduler{}
 
 	server := listeners.NewServer(test.Wallet, a, &test.NodeConfig, test.MasterDB,
 		test.RPCNode, nil, test.Headers, test.Scheduler, tracer, test.UTXOs, txFilter,
 		test.HoldingsChannel)
+
+	if err := server.SyncWallet(ctx); err != nil {
+		b.Fatalf("Failed to load wallet : %s", err)
+	}
 
 	server.SetAlternateResponder(respondTx)
 	server.SetInSync()
@@ -306,17 +305,16 @@ func separateTransfersBenchmark(b *testing.B) {
 	test.NodeConfig.PreprocessThreads = 4
 
 	tracer := filters.NewTracer()
-	walletKeys := test.Wallet.ListAll()
-	pubKeys := make([][]byte, 0, len(walletKeys))
-	for _, walletKey := range walletKeys {
-		pubKeys = append(pubKeys, walletKey.Key.PublicKey().Bytes())
-	}
-	txFilter := filters.NewTxFilter(pubKeys, tracer, true)
+	txFilter := filters.NewTxFilter(tracer, true)
 	test.Scheduler = &scheduler.Scheduler{}
 
 	server := listeners.NewServer(test.Wallet, a, &test.NodeConfig, test.MasterDB,
 		test.RPCNode, nil, test.Headers, test.Scheduler, tracer, test.UTXOs, txFilter,
 		test.HoldingsChannel)
+
+	if err := server.SyncWallet(ctx); err != nil {
+		b.Fatalf("Failed to load wallet : %s", err)
+	}
 
 	server.SetAlternateResponder(respondTx)
 	server.SetInSync()
@@ -508,17 +506,16 @@ func oracleTransfersBenchmark(b *testing.B) {
 	test.NodeConfig.PreprocessThreads = 4
 
 	tracer := filters.NewTracer()
-	walletKeys := test.Wallet.ListAll()
-	pubKeys := make([][]byte, 0, len(walletKeys))
-	for _, walletKey := range walletKeys {
-		pubKeys = append(pubKeys, walletKey.Key.PublicKey().Bytes())
-	}
-	txFilter := filters.NewTxFilter(pubKeys, tracer, true)
+	txFilter := filters.NewTxFilter(tracer, true)
 	test.Scheduler = &scheduler.Scheduler{}
 
 	server := listeners.NewServer(test.Wallet, a, &test.NodeConfig, test.MasterDB,
 		test.RPCNode, nil, test.Headers, test.Scheduler, tracer, test.UTXOs, txFilter,
 		test.HoldingsChannel)
+
+	if err := server.SyncWallet(ctx); err != nil {
+		b.Fatalf("Failed to load wallet : %s", err)
+	}
 
 	server.SetAlternateResponder(respondTx)
 	server.SetInSync()
@@ -748,17 +745,16 @@ func treeTransfersBenchmark(b *testing.B) {
 	test.NodeConfig.PreprocessThreads = 4
 
 	tracer := filters.NewTracer()
-	walletKeys := test.Wallet.ListAll()
-	pubKeys := make([][]byte, 0, len(walletKeys))
-	for _, walletKey := range walletKeys {
-		pubKeys = append(pubKeys, walletKey.Key.PublicKey().Bytes())
-	}
-	txFilter := filters.NewTxFilter(pubKeys, tracer, true)
+	txFilter := filters.NewTxFilter(tracer, true)
 	test.Scheduler = &scheduler.Scheduler{}
 
 	server := listeners.NewServer(test.Wallet, a, &test.NodeConfig, test.MasterDB,
 		test.RPCNode, nil, test.Headers, test.Scheduler, tracer, test.UTXOs, txFilter,
 		test.HoldingsChannel)
+
+	if err := server.SyncWallet(ctx); err != nil {
+		b.Fatalf("Failed to load wallet : %s", err)
+	}
 
 	server.SetAlternateResponder(respondTx)
 	server.SetInSync()

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -62,9 +62,6 @@ func Create(ctx context.Context, dbConn *db.DB, contractAddress bitcoin.RawAddre
 	if contract.VotingSystems == nil {
 		contract.VotingSystems = []*actions.VotingSystemField{}
 	}
-	if contract.Oracles == nil {
-		contract.Oracles = []*actions.OracleField{}
-	}
 	if err := ExpandOracles(ctx, &contract); err != nil {
 		return err
 	}

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -64,10 +64,9 @@ func Create(ctx context.Context, dbConn *db.DB, contractAddress bitcoin.RawAddre
 	}
 	if contract.Oracles == nil {
 		contract.Oracles = []*actions.OracleField{}
-
-		if err := ExpandOracles(ctx, &contract); err != nil {
-			return err
-		}
+	}
+	if err := ExpandOracles(ctx, &contract); err != nil {
+		return err
 	}
 
 	return Save(ctx, dbConn, &contract)

--- a/internal/contract/models.go
+++ b/internal/contract/models.go
@@ -35,7 +35,7 @@ type NewContract struct {
 	RestrictedQtyAssets       uint64                       `json:"RestrictedQtyAssets,omitempty"`
 	AdministrationProposal    bool                         `json:"AdministrationProposal,omitempty"`
 	HolderProposal            bool                         `json:"HolderProposal,omitempty"`
-	Oracle                    []*actions.OracleField       `json:"Oracle,omitempty"`
+	Oracles                   []*actions.OracleField       `json:"Oracles,omitempty"`
 }
 
 // UpdateContract defines what information may be provided to modify an existing

--- a/internal/contract/storage.go
+++ b/internal/contract/storage.go
@@ -90,7 +90,7 @@ func ExpandOracles(ctx context.Context, data *state.Contract) error {
 	// Expand oracle public keys
 	data.FullOracles = make([]bitcoin.PublicKey, 0, len(data.Oracles))
 	for _, key := range data.Oracles {
-		fullKey, err := bitcoin.DecodePublicKeyBytes(key.PublicKey)
+		fullKey, err := bitcoin.PublicKeyFromBytes(key.PublicKey)
 		if err != nil {
 			return err
 		}

--- a/internal/contract/storage.go
+++ b/internal/contract/storage.go
@@ -74,6 +74,8 @@ func Fetch(ctx context.Context, dbConn *db.DB, contractAddress bitcoin.RawAddres
 		return nil, err
 	}
 
+	cache[*contractHash] = &contract
+
 	return &contract, nil
 }
 
@@ -89,8 +91,8 @@ func buildStoragePath(contractHash *bitcoin.Hash20) string {
 func ExpandOracles(ctx context.Context, data *state.Contract) error {
 	// Expand oracle public keys
 	data.FullOracles = make([]bitcoin.PublicKey, 0, len(data.Oracles))
-	for _, key := range data.Oracles {
-		fullKey, err := bitcoin.PublicKeyFromBytes(key.PublicKey)
+	for _, oracle := range data.Oracles {
+		fullKey, err := bitcoin.PublicKeyFromBytes(oracle.PublicKey)
 		if err != nil {
 			return err
 		}

--- a/internal/contract/storage.go
+++ b/internal/contract/storage.go
@@ -74,8 +74,10 @@ func Fetch(ctx context.Context, dbConn *db.DB, contractAddress bitcoin.RawAddres
 		return nil, err
 	}
 
+	if cache == nil {
+		cache = make(map[bitcoin.Hash20]*state.Contract)
+	}
 	cache[*contractHash] = &contract
-
 	return &contract, nil
 }
 

--- a/internal/platform/tests/main.go
+++ b/internal/platform/tests/main.go
@@ -230,7 +230,7 @@ func NewContext() context.Context {
 
 // GenerateKey generates a new wallet key.
 func GenerateKey(net bitcoin.Network) (*wallet.Key, error) {
-	key, err := bitcoin.GenerateKeyS256(net)
+	key, err := bitcoin.GenerateKey(net)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to generate key")
 	}
@@ -239,7 +239,7 @@ func GenerateKey(net bitcoin.Network) (*wallet.Key, error) {
 		Key: key,
 	}
 
-	result.Address, err = bitcoin.NewRawAddressPKH(bitcoin.Hash160(key.PublicKey().Bytes()))
+	result.Address, err = key.RawAddress()
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create key address")
 	}

--- a/pkg/bitcoin/extended_key.go
+++ b/pkg/bitcoin/extended_key.go
@@ -94,7 +94,32 @@ func ExtendedKeyFromBytes(b []byte) (ExtendedKey, error) {
 		return fromBIP32(bip32Key)
 	}
 
-	return readExtendedKey(buf)
+	var result ExtendedKey
+	err = result.read(buf)
+	return result, err
+}
+
+// ExtendedKeyFromBytes creates a key from bytes.
+func (k *ExtendedKey) Deserialize(buf *bytes.Reader) error {
+	header, err := buf.ReadByte()
+	if err != nil {
+		return errors.Wrap(err, "read header")
+	}
+	if header != ExtendedKeyHeader {
+		// Fall back to BIP-0032 format
+		b := make([]byte, 82)
+		if _, err := buf.Read(b); err != nil {
+			return err
+		}
+		bip32Key, err := bip32.Deserialize(b)
+		if err != nil {
+			return ErrNotExtendedKey
+		}
+
+		return k.setFromBIP32(bip32Key)
+	}
+
+	return k.read(buf)
 }
 
 // ExtendedKeyFromStr creates a key from a hex string.
@@ -163,16 +188,21 @@ func (k *ExtendedKey) SetBytes(b []byte) error {
 // Bytes returns the key data.
 func (k ExtendedKey) Bytes() []byte {
 	var buf bytes.Buffer
-
-	if err := buf.WriteByte(ExtendedKeyHeader); err != nil {
-		return nil
-	}
-
-	if err := writeExtendedKey(k, &buf); err != nil {
-		return nil
-	}
-
+	k.Serialize(&buf)
 	return buf.Bytes()
+}
+
+// Serialize writes the key data.
+func (k ExtendedKey) Serialize(buf *bytes.Buffer) error {
+	if err := buf.WriteByte(ExtendedKeyHeader); err != nil {
+		return err
+	}
+
+	if err := k.write(buf); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns the key formatted as hex text.
@@ -384,62 +414,61 @@ func (k *ExtendedKey) setFromBIP32(old *bip32.Key) error {
 	return nil
 }
 
-// readExtendedKey reads just the basic data of the extended key.
-func readExtendedKey(buf *bytes.Reader) (ExtendedKey, error) {
-	var result ExtendedKey
+// read reads just the basic data of the extended key.
+func (k *ExtendedKey) read(buf *bytes.Reader) error {
 	var err error
 
-	result.Depth, err = buf.ReadByte()
+	k.Depth, err = buf.ReadByte()
 	if err != nil {
-		return result, errors.Wrap(err, "reading xkey depth")
+		return errors.Wrap(err, "reading xkey depth")
 	}
 
-	_, err = buf.Read(result.FingerPrint[:])
+	_, err = buf.Read(k.FingerPrint[:])
 	if err != nil {
-		return result, errors.Wrap(err, "reading xkey fingerprint")
+		return errors.Wrap(err, "reading xkey fingerprint")
 	}
 
-	err = binary.Read(buf, binary.BigEndian, &result.Index)
+	err = binary.Read(buf, binary.BigEndian, &k.Index)
 	if err != nil {
-		return result, errors.Wrap(err, "reading xkey index")
+		return errors.Wrap(err, "reading xkey index")
 	}
 
-	_, err = buf.Read(result.ChainCode[:])
+	_, err = buf.Read(k.ChainCode[:])
 	if err != nil {
-		return result, errors.Wrap(err, "reading xkey chaincode")
+		return errors.Wrap(err, "reading xkey chaincode")
 	}
 
-	_, err = buf.Read(result.KeyValue[:])
+	_, err = buf.Read(k.KeyValue[:])
 	if err != nil {
-		return result, errors.Wrap(err, "reading xkey key")
+		return errors.Wrap(err, "reading xkey key")
 	}
 
-	return result, nil
+	return nil
 }
 
-// writeExtendedKey writes just the basic data of the extended key.
-func writeExtendedKey(ek ExtendedKey, buf *bytes.Buffer) error {
-	err := buf.WriteByte(ek.Depth)
+// write writes just the basic data of the extended key.
+func (k ExtendedKey) write(buf *bytes.Buffer) error {
+	err := buf.WriteByte(k.Depth)
 	if err != nil {
 		return errors.Wrap(err, "writing xkey depth")
 	}
 
-	_, err = buf.Write(ek.FingerPrint[:])
+	_, err = buf.Write(k.FingerPrint[:])
 	if err != nil {
 		return errors.Wrap(err, "writing xkey fingerprint")
 	}
 
-	err = binary.Write(buf, binary.BigEndian, ek.Index)
+	err = binary.Write(buf, binary.BigEndian, k.Index)
 	if err != nil {
 		return errors.Wrap(err, "writing xkey index")
 	}
 
-	_, err = buf.Write(ek.ChainCode[:])
+	_, err = buf.Write(k.ChainCode[:])
 	if err != nil {
 		return errors.Wrap(err, "writing xkey chaincode")
 	}
 
-	_, err = buf.Write(ek.KeyValue[:])
+	_, err = buf.Write(k.KeyValue[:])
 	if err != nil {
 		return errors.Wrap(err, "writing xkey key")
 	}

--- a/pkg/bitcoin/extended_key.go
+++ b/pkg/bitcoin/extended_key.go
@@ -224,9 +224,9 @@ func (k ExtendedKey) IsPrivate() bool {
 // Key returns the (private) key associated with this key.
 func (k ExtendedKey) Key(net Network) Key {
 	if !k.IsPrivate() {
-		return nil
+		return Key{}
 	}
-	result, _ := KeyS256FromBytes(k.KeyValue[1:], net) // Skip first zero byte. We just want the 32 byte key value.
+	result, _ := KeyFromNumber(k.KeyValue[1:], net) // Skip first zero byte. We just want the 32 byte key value.
 	return result
 }
 
@@ -235,13 +235,13 @@ func (k ExtendedKey) PublicKey() PublicKey {
 	if k.IsPrivate() {
 		return k.Key(MainNet).PublicKey()
 	}
-	pub, _ := DecodePublicKeyBytes(k.KeyValue[:])
+	pub, _ := PublicKeyFromBytes(k.KeyValue[:])
 	return pub
 }
 
 // RawAddress returns a raw address for this key.
 func (k ExtendedKey) RawAddress() (RawAddress, error) {
-	return NewRawAddressPKH(Hash160(k.PublicKey().Bytes()))
+	return k.PublicKey().RawAddress()
 }
 
 // ExtendedPublicKey returns the public version of this key.
@@ -251,8 +251,7 @@ func (k ExtendedKey) ExtendedPublicKey() ExtendedKey {
 	}
 
 	result := k
-	copy(result.KeyValue[:], k.Key(MainNet).PublicKey().Bytes())
-
+	copy(result.KeyValue[:], k.Key(InvalidNet).PublicKey().Bytes())
 	return result
 }
 
@@ -309,7 +308,7 @@ func (k ExtendedKey) ChildKey(index uint32) (ExtendedKey, error) {
 			return result, errors.Wrap(err, "child add private")
 		}
 	} else {
-		privateKey, err := KeyS256FromBytes(sum[:32], MainNet)
+		privateKey, err := KeyFromNumber(sum[:32], MainNet)
 		if err != nil {
 			return result, errors.Wrap(err, "parse child private key")
 		}

--- a/pkg/bitcoin/extended_keys.go
+++ b/pkg/bitcoin/extended_keys.go
@@ -211,7 +211,7 @@ func (k ExtendedKeys) Equal(other ExtendedKeys) bool {
 }
 
 // RawAddress returns a raw address for this list of keys.
-func (k ExtendedKeys) RawAddress(requiredSigners uint16) (RawAddress, error) {
+func (k ExtendedKeys) RawAddress(requiredSigners int) (RawAddress, error) {
 	if len(k) == 1 {
 		return k[0].RawAddress()
 	}

--- a/pkg/bitcoin/extended_keys.go
+++ b/pkg/bitcoin/extended_keys.go
@@ -42,15 +42,15 @@ func ExtendedKeysFromBytes(b []byte) (ExtendedKeys, error) {
 		return ExtendedKeys{result}, nil
 	}
 
-	count, err := readBase128VarInt(buf)
+	count, err := ReadBase128VarInt(buf)
 	if err != nil {
 		return nil, errors.Wrap(err, "read count")
 	}
 
 	result := make(ExtendedKeys, 0, count)
 	for i := 0; i < count; i++ {
-		ek, err := readExtendedKey(buf)
-		if err != nil {
+		var ek ExtendedKey
+		if err := ek.read(buf); err != nil {
 			return nil, errors.Wrap(err, "read xkey base")
 		}
 		result = append(result, ek)
@@ -144,12 +144,12 @@ func (k ExtendedKeys) Bytes() []byte {
 		return nil
 	}
 
-	if err := writeBase128VarInt(&buf, len(k)); err != nil {
+	if err := WriteBase128VarInt(&buf, len(k)); err != nil {
 		return nil
 	}
 
 	for _, key := range k {
-		if err := writeExtendedKey(key, &buf); err != nil {
+		if err := key.write(&buf); err != nil {
 			return nil
 		}
 	}
@@ -281,7 +281,7 @@ func (k *ExtendedKeys) Scan(data interface{}) error {
 	return k.SetBytes(c)
 }
 
-func readBase128VarInt(r io.ByteReader) (int, error) {
+func ReadBase128VarInt(r io.ByteReader) (int, error) {
 	value := uint32(0)
 	done := false
 	bitOffset := uint32(0)
@@ -301,7 +301,7 @@ func readBase128VarInt(r io.ByteReader) (int, error) {
 	return int(value), nil
 }
 
-func writeBase128VarInt(w io.ByteWriter, value int) error {
+func WriteBase128VarInt(w io.ByteWriter, value int) error {
 	v := uint32(value)
 	for {
 		if v < 128 {

--- a/pkg/bitcoin/key.go
+++ b/pkg/bitcoin/key.go
@@ -30,6 +30,7 @@ const (
 
 var (
 	ErrBadKeyType = errors.New("Key type unknown")
+	ErrOutOfRangeKey = errors.New("Out of range key")
 )
 
 // Key is an elliptic curve private key using the secp256k1 elliptic curve.
@@ -210,12 +211,12 @@ var zeroKeyValue [32]byte
 func privateKeyIsValid(b []byte) error {
 	// Check for zero private key
 	if bytes.Equal(b, zeroKeyValue[:]) {
-		return errors.New("Zero private key")
+		return ErrOutOfRangeKey
 	}
 
 	// Check for key outside curve
 	if bytes.Compare(b, curveS256Params.N.Bytes()) >= 0 {
-		return errors.New("Out of range private key")
+		return ErrOutOfRangeKey
 	}
 
 	return nil

--- a/pkg/bitcoin/key.go
+++ b/pkg/bitcoin/key.go
@@ -29,7 +29,7 @@ const (
 )
 
 var (
-	ErrBadKeyType = errors.New("Key type unknown")
+	ErrBadKeyType    = errors.New("Key type unknown")
 	ErrOutOfRangeKey = errors.New("Out of range key")
 )
 

--- a/pkg/bitcoin/key_test.go
+++ b/pkg/bitcoin/key_test.go
@@ -36,7 +36,7 @@ func TestKey(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			key, err := KeyS256FromBytes(data, tt.net)
+			key, err := KeyFromNumber(data, tt.net)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -54,7 +54,7 @@ func TestKey(t *testing.T) {
 				t.Errorf("Ext WIF encode: got %x, want %x", extwif.PrivKey.Serialize(), data)
 			}
 
-			reverseKey, err := DecodeKeyString(tt.wif)
+			reverseKey, err := KeyFromStr(tt.wif)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/bitcoin/lock_script.go
+++ b/pkg/bitcoin/lock_script.go
@@ -246,7 +246,7 @@ func RawAddressFromLockingScript(lockingScript []byte) (RawAddress, error) {
 		}
 		script = script[1:]
 
-		err = result.SetMultiPKH(uint16(required), pkhs)
+		err = result.SetMultiPKH(int(required), pkhs)
 		return result, err
 	}
 

--- a/pkg/bitcoin/public_key.go
+++ b/pkg/bitcoin/public_key.go
@@ -145,7 +145,7 @@ func publicKeyIsValid(k []byte) error {
 	x, y := expandPublicKey(k)
 
 	if x.Sign() == 0 || y.Sign() == 0 {
-		return errors.New("invalid public key")
+		return ErrOutOfRangeKey
 	}
 
 	return nil

--- a/pkg/bitcoin/public_key.go
+++ b/pkg/bitcoin/public_key.go
@@ -1,74 +1,108 @@
 package bitcoin
 
 import (
+	"encoding/hex"
 	"math/big"
 
-	"github.com/btcsuite/btcd/btcec"
 	"github.com/pkg/errors"
 )
 
-type PublicKey interface {
-	// String returns the serialized compressed public key with a checksum, encoded with Base58.
-	String() string
-
-	// Bytes returns the serialized compressed public key.
-	Bytes() []byte
-
-	// Numbers returns the numeric values of the x and y coordinates.
-	Numbers() ([]byte, []byte)
+// PublicKey is an elliptic curve public key using the secp256k1 elliptic curve.
+type PublicKey struct {
+	X, Y big.Int
 }
 
-// DecodePublicKeyString converts key text to a key.
-func DecodePublicKeyString(s string) (PublicKey, error) {
-	b, err := decodeAddress(s)
+// PublicKeyFromString converts key text to a key.
+func PublicKeyFromStr(s string) (PublicKey, error) {
+	b, err := hex.DecodeString(s)
 	if err != nil {
-		return nil, err
+		return PublicKey{}, err
 	}
 
-	return DecodePublicKeyBytes(b)
+	return PublicKeyFromBytes(b)
 }
 
-// DecodePublicKeyBytes decodes a binary bitcoin public key. It returns the key and an error if
+// PublicKeyFromBytes decodes a binary bitcoin public key. It returns the key and an error if
 //   there was an issue.
-func DecodePublicKeyBytes(b []byte) (PublicKey, error) {
-	result, err := PublicKeyS256FromBytes(b)
-	return result, err
+func PublicKeyFromBytes(b []byte) (PublicKey, error) {
+	if len(b) != 33 {
+		return PublicKey{}, errors.New("Invalid public key length")
+	}
+
+	x, y := expandPublicKey(b)
+	return PublicKey{X: x, Y: y}, nil
 }
 
-/****************************************** S256 **************************************************
-/* An elliptic curve public key using the secp256k1 elliptic curve.
-*/
-type PublicKeyS256 struct {
-	key *btcec.PublicKey
-}
-
-// PublicKeyS256FromBytes creates a key from a serialized compressed public key.
-func PublicKeyS256FromBytes(key []byte) (*PublicKeyS256, error) {
-	pubkey, err := btcec.ParsePubKey(key, curveS256)
-	return &PublicKeyS256{key: pubkey}, err
-}
-
-// publicKeyS256FromBTCEC creates a key from a btcec public key.
-func publicKeyS256FromBTCEC(key *btcec.PublicKey) *PublicKeyS256 {
-	return &PublicKeyS256{key: key}
+// RawAddress returns a raw address for this key.
+func (k PublicKey) RawAddress() (RawAddress, error) {
+	return NewRawAddressPKH(Hash160(k.Bytes()))
 }
 
 // String returns the key data with a checksum, encoded with Base58.
-func (k *PublicKeyS256) String() string {
-	return encodeAddress(k.Bytes())
+func (k PublicKey) String() string {
+	return hex.EncodeToString(k.Bytes())
+}
+
+// SetString decodes a public key from hex text.
+func (k *PublicKey) SetString(s string) error {
+	nk, err := PublicKeyFromStr(s)
+	if err != nil {
+		return err
+	}
+
+	*k = nk
+	return nil
+}
+
+// SetBytes decodes the key from bytes.
+func (k *PublicKey) SetBytes(b []byte) error {
+	nk, err := PublicKeyFromBytes(b)
+	if err != nil {
+		return err
+	}
+
+	*k = nk
+	return nil
 }
 
 // Bytes returns serialized compressed key data.
-func (k *PublicKeyS256) Bytes() []byte {
-	return k.key.SerializeCompressed()
+func (k PublicKey) Bytes() []byte {
+	return compressPublicKey(k.X, k.Y)
 }
 
 // Numbers returns the 32 byte values representing the 256 bit big-endian integer of the x and y coordinates.
-func (k *PublicKeyS256) Numbers() ([]byte, []byte) {
-	return k.key.X.Bytes(), k.key.Y.Bytes()
+func (k PublicKey) Numbers() ([]byte, []byte) {
+	return k.X.Bytes(), k.Y.Bytes()
 }
 
-func compressPublicKey(x *big.Int, y *big.Int) []byte {
+// IsEmpty returns true if the value is zero.
+func (k PublicKey) IsEmpty() bool {
+	return k.X.Cmp(&zeroBigInt) == 0 && k.Y.Cmp(&zeroBigInt) == 0
+}
+
+// MarshalJSON converts to json.
+func (k *PublicKey) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + k.String() + "\""), nil
+}
+
+// UnmarshalJSON converts from json.
+func (k *PublicKey) UnmarshalJSON(data []byte) error {
+	return k.SetString(string(data[1 : len(data)-1]))
+}
+
+// Scan converts from a database column.
+func (k *PublicKey) Scan(data interface{}) error {
+	b, ok := data.([]byte)
+	if !ok {
+		return errors.New("Public Key db column not bytes")
+	}
+
+	c := make([]byte, len(b))
+	copy(c, b)
+	return k.SetBytes(c)
+}
+
+func compressPublicKey(x big.Int, y big.Int) []byte {
 	result := make([]byte, 33)
 
 	// Header byte is 0x02 for even y value and 0x03 for odd
@@ -82,26 +116,26 @@ func compressPublicKey(x *big.Int, y *big.Int) []byte {
 	return result
 }
 
-func expandPublicKey(k []byte) (*big.Int, *big.Int) {
-	y := big.NewInt(0)
-	x := big.NewInt(0)
+func expandPublicKey(k []byte) (big.Int, big.Int) {
+	y := big.Int{}
+	x := big.Int{}
 	x.SetBytes(k[1:])
 
 	// y^2 = x^3 + ax^2 + b
 	// a = 0
 	// => y^2 = x^3 + b
 	ySq := big.NewInt(0)
-	ySq.Exp(x, big.NewInt(3), nil)
+	ySq.Exp(&x, big.NewInt(3), nil)
 	ySq.Add(ySq, curveS256Params.B)
 
 	y.ModSqrt(ySq, curveS256Params.P)
 
 	Ymod := big.NewInt(0)
-	Ymod.Mod(y, big.NewInt(2))
+	Ymod.Mod(&y, big.NewInt(2))
 
 	signY := uint64(k[0]) - 2
 	if signY != Ymod.Uint64() {
-		y.Sub(curveS256Params.P, y)
+		y.Sub(curveS256Params.P, &y)
 	}
 
 	return x, y
@@ -120,5 +154,6 @@ func publicKeyIsValid(k []byte) error {
 func addPublicKeys(key1 []byte, key2 []byte) []byte {
 	x1, y1 := expandPublicKey(key1)
 	x2, y2 := expandPublicKey(key2)
-	return compressPublicKey(curveS256.Add(x1, y1, x2, y2))
+	x, y := curveS256.Add(&x1, &y1, &x2, &y2)
+	return compressPublicKey(*x, *y)
 }

--- a/pkg/bitcoin/raw_address.go
+++ b/pkg/bitcoin/raw_address.go
@@ -66,12 +66,12 @@ func (ra *RawAddress) Decode(b []byte) error {
 		buf := bytes.NewBuffer(b)
 		var required int
 		var err error
-		if required, err = readBase128VarInt(buf); err != nil {
+		if required, err = ReadBase128VarInt(buf); err != nil {
 			return err
 		}
 		// Parse hash count
 		var count int
-		if count, err = readBase128VarInt(buf); err != nil {
+		if count, err = ReadBase128VarInt(buf); err != nil {
 			return err
 		}
 		pkhs := make([][]byte, 0, count)
@@ -137,12 +137,12 @@ func (ra *RawAddress) Deserialize(buf *bytes.Reader) error {
 		// Parse required count
 		var required int
 		var err error
-		if required, err = readBase128VarInt(buf); err != nil {
+		if required, err = ReadBase128VarInt(buf); err != nil {
 			return err
 		}
 		// Parse hash count
 		var count int
-		if count, err = readBase128VarInt(buf); err != nil {
+		if count, err = ReadBase128VarInt(buf); err != nil {
 			return err
 		}
 		pkhs := make([][]byte, 0, count)
@@ -251,10 +251,10 @@ func (ra *RawAddress) SetMultiPKH(required int, pkhs [][]byte) error {
 	ra.scriptType = ScriptTypeMultiPKH
 	buf := bytes.NewBuffer(make([]byte, 0, 4+(len(pkhs)*ScriptHashLength)))
 
-	if err := writeBase128VarInt(buf, required); err != nil {
+	if err := WriteBase128VarInt(buf, required); err != nil {
 		return err
 	}
-	if err := writeBase128VarInt(buf, len(pkhs)); err != nil {
+	if err := WriteBase128VarInt(buf, len(pkhs)); err != nil {
 		return err
 	}
 	for _, pkh := range pkhs {

--- a/pkg/bitcoin/signature.go
+++ b/pkg/bitcoin/signature.go
@@ -1,71 +1,408 @@
 package bitcoin
 
 import (
-	"github.com/btcsuite/btcd/btcec"
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"math/big"
 )
 
-type Signature interface {
-	// String returns the serialized signature with a checksum, encoded with Base58.
-	String() string
-
-	// Bytes returns the serialized signature.
-	Bytes() []byte
-
-	// Verify returns true if the signature is valid for this public key and hash.
-	Verify(hash []byte, pubkey PublicKey) bool
-}
-
-// DecodeSignatureString converts key text to a key.
-func DecodeSignatureString(s string) (Signature, error) {
-	b, err := decodeAddress(s)
-	if err != nil {
-		return nil, err
-	}
-
-	return DecodeSignatureBytes(b)
-}
-
-// DecodeSignatureBytes decodes a binary bitcoin signature. It returns the signature and an error if
-//   there was an issue.
-func DecodeSignatureBytes(b []byte) (Signature, error) {
-	result, err := SignatureS256FromBytes(b)
-	return result, err
-}
-
-/****************************************** S256 **************************************************
-/* An elliptic curve signature using the secp256k1 elliptic curve.
-*/
-type SignatureS256 struct {
-	sig *btcec.Signature
-}
-
-// SignatureS256FromBytes creates a key from a serialized signature.
-func SignatureS256FromBytes(sig []byte) (*SignatureS256, error) {
-	signature, err := btcec.ParseSignature(sig, curveS256)
-	return &SignatureS256{sig: signature}, err
-}
-
-// SignatureS256FromBTCEC creates a key from a btcec signature.
-func SignatureS256FromBTCEC(sig *btcec.Signature) *SignatureS256 {
-	return &SignatureS256{sig: sig}
-}
-
-// String returns the signature data with a checksum, encoded with Base58.
-func (s *SignatureS256) String() string {
-	return encodeAddress(s.Bytes())
-}
-
-// Bytes returns serialized compressed key data.
-func (s *SignatureS256) Bytes() []byte {
-	return s.sig.Serialize()
+// Signature is an elliptic curve signature using the secp256k1 elliptic curve.
+type Signature struct {
+	R big.Int
+	S big.Int
 }
 
 // Verify returns true if the signature is valid for this public key and hash.
-func (s *SignatureS256) Verify(hash []byte, pubkey PublicKey) bool {
-	pk, ok := pubkey.(*PublicKeyS256)
-	if !ok {
-		return false
+func (s Signature) Verify(hash []byte, pubkey PublicKey) bool {
+	ecPubKey := &ecdsa.PublicKey{
+		curveS256,
+		&pubkey.X,
+		&pubkey.Y,
+	}
+	return ecdsa.Verify(ecPubKey, hash, &s.R, &s.S)
+}
+
+// SignatureFromStr converts key text to a key.
+func SignatureFromStr(s string) (Signature, error) {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return Signature{}, err
 	}
 
-	return s.sig.Verify(hash, pk.key)
+	return SignatureFromBytes(b)
+}
+
+// SignatureFromBytes decodes a binary bitcoin signature. It returns the signature and an error if
+//   there was an issue.
+func SignatureFromBytes(b []byte) (Signature, error) {
+	// 0x30 <length of whole message> <0x02> <length of R> <R> 0x2
+	// <length of S> <S>.
+
+	if len(b) < 8 {
+		return Signature{}, errors.New("Signature too short")
+	}
+	// 0x30
+	index := 0
+	if b[index] != 0x30 {
+		return Signature{}, errors.New("Signature missing header byte")
+	}
+	index++
+	// length of remaining message
+	length := b[index]
+	index++
+
+	// length should be less than the entire message and greater than
+	// the minimal message size.
+	if int(length+2) > len(b) || int(length+2) < 8 {
+		return Signature{}, errors.New("Signature has bad length")
+	}
+	// trim the slice we're working on so we only look at what matters.
+	b = b[:length+2]
+
+	// 0x02
+	if b[index] != 0x02 {
+		return Signature{}, errors.New("Signature missing 1st int marker")
+	}
+	index++
+
+	// Length of R.
+	rLen := int(b[index])
+	// must be positive, must be able to fit in another 0x2, <len> <s>
+	// hence the -3. We assume that the length must be at least one byte.
+	index++
+	if rLen <= 0 || rLen > len(b)-index-3 {
+		return Signature{}, errors.New("Signature has bad R length")
+	}
+
+	// Then R itself.
+	rBytes := b[index : index+rLen]
+	switch err := canonicalPadding(rBytes); err {
+	case errNegativeValue:
+		return Signature{}, errors.New("Signature R is negative")
+	case errExcessivelyPaddedValue:
+		return Signature{}, errors.New("Signature R is excessively padded")
+	}
+	var r big.Int
+	r.SetBytes(rBytes)
+	index += rLen
+	// 0x02. length already checked in previous if.
+	if b[index] != 0x02 {
+		return Signature{}, errors.New("malformed signature: no 2nd int marker")
+	}
+	index++
+
+	// Length of signature S.
+	sLen := int(b[index])
+	index++
+	// S should be the rest of the string.
+	if sLen <= 0 || sLen > len(b)-index {
+		return Signature{}, errors.New("Signature has bad S length")
+	}
+
+	// Then S itself.
+	sBytes := b[index : index+sLen]
+	switch err := canonicalPadding(sBytes); err {
+	case errNegativeValue:
+		return Signature{}, errors.New("Signature S is negative")
+	case errExcessivelyPaddedValue:
+		return Signature{}, errors.New("Signature S is excessively padded")
+	}
+	var s big.Int
+	s.SetBytes(sBytes)
+	index += sLen
+
+	// sanity check length parsing
+	if index != len(b) {
+		return Signature{}, fmt.Errorf("Signature has bad final length %v != %v", index, len(b))
+	}
+
+	// Verify also checks this, but we can be more sure that we parsed
+	// correctly if we verify here too.
+	// FWIW the ecdsa spec states that R and S must be | 1, N - 1 |
+	// but crypto/ecdsa only checks for Sign != 0. Mirror that.
+	if r.Sign() != 1 {
+		return Signature{}, errors.New("signature R isn't 1 or more")
+	}
+	if s.Sign() != 1 {
+		return Signature{}, errors.New("signature S isn't 1 or more")
+	}
+	if r.Cmp(curveS256Params.N) >= 0 {
+		return Signature{}, errors.New("signature R is >= curve.N")
+	}
+	if s.Cmp(curveS256Params.N) >= 0 {
+		return Signature{}, errors.New("signature S is >= curve.N")
+	}
+
+	return Signature{R: r, S: s}, nil
+}
+
+// String returns the signature data with a checksum, encoded with Base58.
+func (s Signature) String() string {
+	return hex.EncodeToString(s.Bytes())
+}
+
+// SetString decodes a signature from hex text.
+func (s *Signature) SetString(str string) error {
+	ns, err := SignatureFromStr(str)
+	if err != nil {
+		return err
+	}
+
+	*s = ns
+	return nil
+}
+
+// SetBytes decodes the signature from bytes.
+func (s *Signature) SetBytes(b []byte) error {
+	ns, err := SignatureFromBytes(b)
+	if err != nil {
+		return err
+	}
+
+	*s = ns
+	return nil
+}
+
+// Bytes returns serialized compressed key data.
+func (s Signature) Bytes() []byte {
+	// low 'S' malleability breaker
+	sigS := s.S
+	if sigS.Cmp(curveHalfOrder) == 1 {
+		sigS.Sub(curveS256.N, &sigS)
+	}
+	// Ensure the encoded bytes for the r and s values are canonical and
+	// thus suitable for DER encoding.
+	rb := canonicalizeInt(s.R)
+	sb := canonicalizeInt(sigS)
+
+	// total length of returned signature is 1 byte for each magic and
+	// length (6 total), plus lengths of r and s
+	length := 6 + len(rb) + len(sb)
+	b := make([]byte, length)
+
+	b[0] = 0x30
+	b[1] = byte(length - 2)
+	b[2] = 0x02
+	b[3] = byte(len(rb))
+	offset := copy(b[4:], rb) + 4
+	b[offset] = 0x02
+	b[offset+1] = byte(len(sb))
+	copy(b[offset+2:], sb)
+	return b
+}
+
+// MarshalJSON converts to json.
+func (s *Signature) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + s.String() + "\""), nil
+}
+
+// UnmarshalJSON converts from json.
+func (s *Signature) UnmarshalJSON(data []byte) error {
+	return s.SetString(string(data[1 : len(data)-1]))
+}
+
+// Scan converts from a database column.
+func (s *Signature) Scan(data interface{}) error {
+	b, ok := data.([]byte)
+	if !ok {
+		return errors.New("Public Key db column not bytes")
+	}
+
+	c := make([]byte, len(b))
+	copy(c, b)
+	return s.SetBytes(c)
+}
+
+/********************************************* RFC6979 ********************************************/
+var (
+	// Used in RFC6979 implementation when testing the nonce for correctness
+	one = big.NewInt(1)
+
+	// oneInitializer is used to fill a byte slice with byte 0x01.  It is provided
+	// here to avoid the need to create it multiple times.
+	oneInitializer = []byte{0x01}
+
+	// Errors returned by canonicalPadding.
+	errNegativeValue          = errors.New("value may be interpreted as negative")
+	errExcessivelyPaddedValue = errors.New("value is excessively padded")
+)
+
+// signRFC6979 generates a deterministic ECDSA signature according to RFC 6979 and BIP 62.
+func signRFC6979(pk big.Int, hash []byte) (Signature, error) {
+
+	N := curveS256.N
+	k := nonceRFC6979(pk, hash)
+	inv := new(big.Int).ModInverse(k, N)
+	r, _ := curveS256.ScalarBaseMult(k.Bytes())
+	r.Mod(r, N)
+
+	if r.Sign() == 0 {
+		return Signature{}, errors.New("calculated R is zero")
+	}
+
+	e := hashToInt(hash, curveS256)
+	s := new(big.Int).Mul(&pk, r)
+	s.Add(s, e)
+	s.Mul(s, inv)
+	s.Mod(s, N)
+
+	if s.Cmp(curveHalfOrder) == 1 {
+		s.Sub(N, s)
+	}
+	if s.Sign() == 0 {
+		return Signature{}, errors.New("calculated S is zero")
+	}
+	return Signature{R: *r, S: *s}, nil
+}
+
+// nonceRFC6979 generates an ECDSA nonce (`k`) deterministically according to RFC 6979.
+// It takes a 32-byte hash as an input and returns 32-byte nonce to be used in ECDSA algorithm.
+func nonceRFC6979(pk big.Int, hash []byte) *big.Int {
+
+	q := curveS256Params.N
+	alg := sha256.New
+
+	qlen := q.BitLen()
+	holen := alg().Size()
+	rolen := (qlen + 7) >> 3
+	bx := append(int2octets(pk, rolen), bits2octets(hash, curveS256, rolen)...)
+
+	// Step B
+	v := bytes.Repeat(oneInitializer, holen)
+
+	// Step C (Go zeroes the all allocated memory)
+	k := make([]byte, holen)
+
+	// Step D
+	k = mac(alg, k, append(append(v, 0x00), bx...))
+
+	// Step E
+	v = mac(alg, k, v)
+
+	// Step F
+	k = mac(alg, k, append(append(v, 0x01), bx...))
+
+	// Step G
+	v = mac(alg, k, v)
+
+	// Step H
+	for {
+		// Step H1
+		var t []byte
+
+		// Step H2
+		for len(t)*8 < qlen {
+			v = mac(alg, k, v)
+			t = append(t, v...)
+		}
+
+		// Step H3
+		secret := hashToInt(t, curveS256)
+		if secret.Cmp(one) >= 0 && secret.Cmp(q) < 0 {
+			return secret
+		}
+		k = mac(alg, k, append(v, 0x00))
+		v = mac(alg, k, v)
+	}
+}
+
+// mac returns an HMAC of the given key and message.
+func mac(alg func() hash.Hash, k, m []byte) []byte {
+	h := hmac.New(alg, k)
+	h.Write(m)
+	return h.Sum(nil)
+}
+
+// https://tools.ietf.org/html/rfc6979#section-2.3.3
+func int2octets(v big.Int, rolen int) []byte {
+	out := v.Bytes()
+
+	// left pad with zeros if it's too short
+	if len(out) < rolen {
+		out2 := make([]byte, rolen)
+		copy(out2[rolen-len(out):], out)
+		return out2
+	}
+
+	// drop most significant bytes if it's too long
+	if len(out) > rolen {
+		out2 := make([]byte, rolen)
+		copy(out2, out[len(out)-rolen:])
+		return out2
+	}
+
+	return out
+}
+
+// https://tools.ietf.org/html/rfc6979#section-2.3.4
+func bits2octets(in []byte, curve elliptic.Curve, rolen int) []byte {
+	z1 := hashToInt(in, curve)
+	z2 := new(big.Int).Sub(z1, curve.Params().N)
+	if z2.Sign() < 0 {
+		return int2octets(*z1, rolen)
+	}
+	return int2octets(*z2, rolen)
+}
+
+// canonicalizeInt returns the bytes for the passed big integer adjusted as
+// necessary to ensure that a big-endian encoded integer can't possibly be
+// misinterpreted as a negative number.  This can happen when the most
+// significant bit is set, so it is padded by a leading zero byte in this case.
+// Also, the returned bytes will have at least a single byte when the passed
+// value is 0.  This is required for DER encoding.
+func canonicalizeInt(val big.Int) []byte {
+	b := val.Bytes()
+	if len(b) == 0 {
+		b = []byte{0x00}
+	}
+	if b[0]&0x80 != 0 {
+		paddedBytes := make([]byte, len(b)+1)
+		copy(paddedBytes[1:], b)
+		b = paddedBytes
+	}
+	return b
+}
+
+// canonicalPadding checks whether a big-endian encoded integer could
+// possibly be misinterpreted as a negative number (even though OpenSSL
+// treats all numbers as unsigned), or if there is any unnecessary
+// leading zero padding.
+func canonicalPadding(b []byte) error {
+	switch {
+	case b[0]&0x80 == 0x80:
+		return errNegativeValue
+	case len(b) > 1 && b[0] == 0x00 && b[1]&0x80 != 0x80:
+		return errExcessivelyPaddedValue
+	default:
+		return nil
+	}
+}
+
+// hashToInt converts a hash value to an integer. There is some disagreement
+// about how this is done. [NSA] suggests that this is done in the obvious
+// manner, but [SECG] truncates the hash to the bit-length of the curve order
+// first. We follow [SECG] because that's what OpenSSL does. Additionally,
+// OpenSSL right shifts excess bits from the number if the hash is too large
+// and we mirror that too.
+// This is borrowed from crypto/ecdsa.
+func hashToInt(hash []byte, c elliptic.Curve) *big.Int {
+	orderBits := c.Params().N.BitLen()
+	orderBytes := (orderBits + 7) / 8
+	if len(hash) > orderBytes {
+		hash = hash[:orderBytes]
+	}
+
+	ret := new(big.Int).SetBytes(hash)
+	excess := len(hash)*8 - orderBits
+	if excess > 0 {
+		ret.Rsh(ret, uint(excess))
+	}
+	return ret
 }

--- a/pkg/spynode/node.go
+++ b/pkg/spynode/node.go
@@ -346,6 +346,17 @@ func (node *Node) BroadcastTx(ctx context.Context, tx *wire.MsgTx) error {
 		}
 	}
 
+	// Remove tx from list
+	node.config.Lock.Lock()
+	for i, stx := range node.config.ShotgunTxs {
+		if tx == stx {
+			node.config.ShotgunTxs =
+				append(node.config.ShotgunTxs[:i], node.config.ShotgunTxs[i+1:]...)
+			break
+		}
+	}
+	node.config.Lock.Unlock()
+
 	return nil
 }
 
@@ -438,6 +449,17 @@ func (node *Node) ShotgunTransmitTx(ctx context.Context, tx *wire.MsgTx, sendCou
 	}
 
 	node.sleepUntilStop(30) // Wait for handshake
+
+	// Remove tx from list
+	node.config.Lock.Lock()
+	for i, stx := range node.config.ShotgunTxs {
+		if tx == stx {
+			node.config.ShotgunTxs =
+				append(node.config.ShotgunTxs[:i], node.config.ShotgunTxs[i+1:]...)
+			break
+		}
+	}
+	node.config.Lock.Unlock()
 
 	// Stop all
 	node.untrustedLock.Lock()

--- a/pkg/storage/s3_storage.go
+++ b/pkg/storage/s3_storage.go
@@ -202,8 +202,6 @@ func (s S3Storage) findKeys(ctx context.Context,
 
 	svc := s3.New(s.Session)
 
-	fmt.Printf("Bucket : %s\n", s.Config.Bucket)
-	fmt.Printf("Find keys : %s\n", path)
 	input := &s3.ListObjectsV2Input{
 		Bucket: aws.String(s.Config.Bucket),
 		Prefix: &path,

--- a/pkg/txbuilder/txbuilder_test.go
+++ b/pkg/txbuilder/txbuilder_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestBasic(t *testing.T) {
-	key, err := bitcoin.GenerateKeyS256(bitcoin.TestNet)
+	key, err := bitcoin.GenerateKey(bitcoin.TestNet)
 	if err != nil {
 		t.Errorf("Failed to create private key : %s", err)
 	}
@@ -22,7 +22,7 @@ func TestBasic(t *testing.T) {
 		t.Errorf("Failed to create pkh address : %s", err)
 	}
 
-	key2, err := bitcoin.GenerateKeyS256(bitcoin.TestNet)
+	key2, err := bitcoin.GenerateKey(bitcoin.TestNet)
 	if err != nil {
 		t.Errorf("Failed to create private key 2 : %s", err)
 	}
@@ -101,7 +101,7 @@ func TestBasic(t *testing.T) {
 func TestSample(t *testing.T) {
 	// Load your private key
 	wif := "cQDgbH4C7HP3LSJevMSb1dPMCviCPoLwJ28mxnDRJueMSCa72xjm"
-	key, err := bitcoin.DecodeKeyString(wif)
+	key, err := bitcoin.KeyFromStr(wif)
 	if err != nil {
 		t.Fatalf("Failed to decode key : %s", err)
 	}

--- a/pkg/wallet/key.go
+++ b/pkg/wallet/key.go
@@ -3,7 +3,6 @@ package wallet
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 
 	"github.com/tokenized/smart-contract/pkg/bitcoin"
 )
@@ -18,11 +17,7 @@ func NewKey(key bitcoin.Key) *Key {
 		Key: key,
 	}
 
-	s256, ok := key.(*bitcoin.KeyS256)
-	if !ok {
-		return nil
-	}
-	result.Address, _ = bitcoin.NewRawAddressPKH(bitcoin.Hash160(s256.PublicKey().Bytes()))
+	result.Address, _ = key.RawAddress()
 	return &result
 }
 
@@ -38,16 +33,12 @@ func (rk *Key) Read(buf *bytes.Buffer, net bitcoin.Network) error {
 	}
 
 	var err error
-	rk.Key, err = bitcoin.DecodeKeyBytes(data, net)
+	rk.Key, err = bitcoin.KeyFromBytes(data, net)
 	if err != nil {
 		return err
 	}
 
-	s256, ok := rk.Key.(*bitcoin.KeyS256)
-	if !ok {
-		return errors.New("Key is not S256")
-	}
-	rk.Address, err = bitcoin.NewRawAddressPKH(bitcoin.Hash160(s256.PublicKey().Bytes()))
+	rk.Address, _ = rk.Key.RawAddress()
 	return err
 }
 

--- a/pkg/wallet/key.go
+++ b/pkg/wallet/key.go
@@ -21,7 +21,7 @@ func NewKey(key bitcoin.Key) *Key {
 	return &result
 }
 
-func (rk *Key) Read(buf *bytes.Buffer, net bitcoin.Network) error {
+func (rk *Key) Read(buf *bytes.Reader, net bitcoin.Network) error {
 	var length uint8
 	if err := binary.Read(buf, binary.LittleEndian, &length); err != nil {
 		return err

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -61,7 +61,7 @@ func (w Wallet) Register(wif string, net bitcoin.Network) error {
 	}
 
 	// load the WIF if we have one
-	key, err := bitcoin.DecodeKeyString(wif)
+	key, err := bitcoin.KeyFromStr(wif)
 	if err != nil {
 		return err
 	}

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -8,11 +8,10 @@ package wallet
  */
 
 import (
-	"context"
+	"bytes"
 	"errors"
 	"sync"
 
-	"github.com/tokenized/smart-contract/internal/platform/db"
 	"github.com/tokenized/smart-contract/pkg/bitcoin"
 )
 
@@ -20,10 +19,9 @@ type WalletInterface interface {
 	Get(bitcoin.RawAddress) (*Key, error)
 	List([]bitcoin.RawAddress) ([]*Key, error)
 	ListAll() []*Key
-	Add(*Key) error
 	Remove(*Key) error
-	Load(context.Context, *db.DB, bitcoin.Network) error
-	Save(context.Context, *db.DB, bitcoin.Network) error
+	Serialize(*bytes.Buffer) error
+	Deserialize(*bytes.Reader) error
 }
 
 type Wallet struct {
@@ -106,16 +104,16 @@ func (w Wallet) Get(address bitcoin.RawAddress) (*Key, error) {
 	return w.KeyStore.Get(address)
 }
 
-func (w Wallet) Load(ctx context.Context, masterDB *db.DB, net bitcoin.Network) error {
-	w.lock.Lock()
-	defer w.lock.Unlock()
-
-	return w.KeyStore.Load(ctx, masterDB, net)
-}
-
-func (w Wallet) Save(ctx context.Context, masterDB *db.DB, net bitcoin.Network) error {
+func (w Wallet) Serialize(buf *bytes.Buffer) error {
 	w.lock.RLock()
 	defer w.lock.RUnlock()
 
-	return w.KeyStore.Save(ctx, masterDB)
+	return w.KeyStore.Serialize(buf)
+}
+
+func (w Wallet) Deserialize(buf *bytes.Reader) error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	return w.KeyStore.Deserialize(buf)
 }


### PR DESCRIPTION
Overhaul key, public key, and signature classes to reduce dependence on external packages and improve interface.
Update multi-x-key data format to use variable base128 integers to make it more dynamic and also simpler in most scenarios.
Add handling for the rare case when an xkey child index is invalid.
Improve wallet interface to allow external wallet implementations.
Fix oracle issues relating to importing oracles and expanding keys.
Update sign and build commands.
