### PR TITLE
Tx Inspector Get PKHs

### DIFF
--- a/cmd/smartcontract/cmd/cmd_sync.go
+++ b/cmd/smartcontract/cmd/cmd_sync.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/tokenized/smart-contract/cmd/smartcontract/client"
 
 	"github.com/spf13/cobra"
@@ -22,11 +24,16 @@ var cmdSync = &cobra.Command{
 		}
 		theClient, err := client.NewClient(ctx, network(c))
 		if err != nil {
-			return err
+			fmt.Printf("Failed to create client to sync : %s\n", err)
+			return nil
 		}
 
 		dontStopOnSync, _ := c.Flags().GetBool(FlagNoStop)
-		return theClient.RunSpyNode(ctx, !dontStopOnSync)
+		err = theClient.RunSpyNode(ctx, !dontStopOnSync)
+		if err != nil {
+			fmt.Printf("Failed to run spynode : %s\n", err)
+		}
+		return nil
 	},
 }
 

--- a/pkg/bitcoin/hash20.go
+++ b/pkg/bitcoin/hash20.go
@@ -39,6 +39,11 @@ func NewHash20FromStr(s string) (*Hash20, error) {
 	return &result, nil
 }
 
+// NewHash20FromData creates a Hash20 by hashing the data with a Ripemd160(Sha256(b))
+func NewHash20FromData(b []byte) (*Hash20, error) {
+	return NewHash20(Ripemd160(Sha256(b)))
+}
+
 // Bytes returns the data for the hash.
 func (h Hash20) Bytes() []byte {
 	return h[:]

--- a/pkg/spynode/node.go
+++ b/pkg/spynode/node.go
@@ -921,12 +921,12 @@ func (node *Node) scan(ctx context.Context, connections, uncheckedCount int) err
 	if err != nil {
 		return err
 	}
-	logger.Info(ctx, "Found %d peers with no score", len(peers))
+	logger.Verbose(ctx, "Found %d peers with no score", len(peers))
 	if len(peers) < uncheckedCount {
 		return nil // Not enough unchecked peers to run a scan
 	}
 
-	logger.Info(ctx, "Scanning %d peers", connections)
+	logger.Verbose(ctx, "Scanning %d peers", connections)
 
 	count := 0
 	nodes := make([]*UntrustedNode, 0, connections)
@@ -961,10 +961,10 @@ func (node *Node) scan(ctx context.Context, connections, uncheckedCount int) err
 		node.Stop(ctx)
 	}
 
-	logger.Info(ctx, "Waiting for %d scanning nodes to stop", len(nodes))
+	logger.Verbose(ctx, "Waiting for %d scanning nodes to stop", len(nodes))
 	wg.Wait()
 	node.scanning = false
-	logger.Info(ctx, "Finished scanning")
+	logger.Verbose(ctx, "Finished scanning")
 	return nil
 }
 


### PR DESCRIPTION
Implement a function on inspector tx that parses input scripts for public keys, hashes them, parses output scripts for PKHs, and returns the hashes. This adds support for improved tx filtering.