### PR TITLE
JSON Logs

### DIFF
--- a/cmd/smartcontract/client/node.go
+++ b/cmd/smartcontract/client/node.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -76,6 +77,10 @@ func Context() context.Context {
 	// logConfig.Main.MinLevel = logger.LevelDebug
 	logConfig.EnableSubSystem(spynode.SubSystem)
 	logConfig.EnableSubSystem(txbuilder.SubSystem)
+
+	if strings.ToUpper(os.Getenv("CLIENT_LOG_FORMAT")) == "TEXT" {
+		logConfig.IsText = true
+	}
 
 	return logger.ContextWithLogConfig(ctx, logConfig)
 }

--- a/cmd/smartcontractd/bootstrap/bootstrap.go
+++ b/cmd/smartcontractd/bootstrap/bootstrap.go
@@ -29,9 +29,9 @@ func NewContextWithDevelopmentLogger() context.Context {
 			logger.Fatal(ctx, "Failed to open log file : %v\n", err)
 		}
 
-		ctx = node.ContextWithDevelopmentLogger(ctx, logFile)
+		ctx = node.ContextWithDevelopmentLogger(ctx, logFile, os.Getenv("LOG_FORMAT"))
 	} else {
-		ctx = node.ContextWithDevelopmentLogger(ctx, os.Stdout)
+		ctx = node.ContextWithDevelopmentLogger(ctx, os.Stdout, os.Getenv("LOG_FORMAT"))
 	}
 
 	return ctx

--- a/conf/dev.env.bat.example
+++ b/conf/dev.env.bat.example
@@ -40,3 +40,4 @@ set CONTRACT_STORAGE_ROOT=./tmp/contract
 set CONTRACT_STORAGE_BUCKET=standalone
 
 set LOG_FILE_PATH=tmp/contract/main.log
+rem set LOG_FORMAT=text

--- a/conf/dev.env.example
+++ b/conf/dev.env.example
@@ -40,3 +40,4 @@ export CONTRACT_STORAGE_ROOT=./tmp/contract
 export CONTRACT_STORAGE_BUCKET=standalone
 
 export LOG_FILE_PATH=./tmp/contract/main.log
+#export LOG_FORMAT=text

--- a/internal/platform/node/log.go
+++ b/internal/platform/node/log.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"io"
+	"strings"
 
 	"github.com/tokenized/smart-contract/pkg/logger"
 	"github.com/tokenized/smart-contract/pkg/rpcnode"
@@ -11,7 +12,7 @@ import (
 	"github.com/tokenized/smart-contract/pkg/txbuilder"
 )
 
-func ContextWithDevelopmentLogger(ctx context.Context, writer io.Writer) context.Context {
+func ContextWithDevelopmentLogger(ctx context.Context, writer io.Writer, format string) context.Context {
 	logConfig := logger.NewDevelopmentConfig()
 	logConfig.Main.SetWriter(writer)
 	logConfig.Main.Format |= logger.IncludeSystem | logger.IncludeMicro
@@ -19,6 +20,10 @@ func ContextWithDevelopmentLogger(ctx context.Context, writer io.Writer) context
 	logConfig.EnableSubSystem(rpcnode.SubSystem)
 	logConfig.EnableSubSystem(txbuilder.SubSystem)
 	logConfig.EnableSubSystem(scheduler.SubSystem)
+
+	if strings.ToUpper(format) == "TEXT" {
+		logConfig.IsText = true
+	}
 
 	// Configure spynode logs
 	logConfig.SubSystems[spynode.SubSystem] = logger.NewDevelopmentSystemConfig()
@@ -29,7 +34,7 @@ func ContextWithDevelopmentLogger(ctx context.Context, writer io.Writer) context
 	return logger.ContextWithLogConfig(ctx, logConfig)
 }
 
-func ContextWithProductionLogger(ctx context.Context, writer io.Writer) context.Context {
+func ContextWithProductionLogger(ctx context.Context, writer io.Writer, format string) context.Context {
 	logConfig := logger.NewProductionConfig()
 	logConfig.Main.SetWriter(writer)
 	logConfig.Main.Format |= logger.IncludeSystem | logger.IncludeMicro
@@ -37,6 +42,10 @@ func ContextWithProductionLogger(ctx context.Context, writer io.Writer) context.
 	logConfig.EnableSubSystem(txbuilder.SubSystem)
 	logConfig.EnableSubSystem(spynode.SubSystem)
 	logConfig.EnableSubSystem(scheduler.SubSystem)
+
+	if strings.ToUpper(format) == "TEXT" {
+		logConfig.IsText = true
+	}
 
 	return logger.ContextWithLogConfig(ctx, logConfig)
 }

--- a/internal/platform/tests/main.go
+++ b/internal/platform/tests/main.go
@@ -63,7 +63,7 @@ func New(logFileName string) *Test {
 			fmt.Printf("Failed to open log file : %v\n", err)
 			return nil
 		}
-		ctx = node.ContextWithDevelopmentLogger(NewContext(), logFile)
+		ctx = node.ContextWithDevelopmentLogger(NewContext(), logFile, "text")
 	} else {
 		ctx = node.ContextWithNoLogger(NewContext())
 	}

--- a/pkg/logger/config.go
+++ b/pkg/logger/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	Main               *SystemConfig
 	IncludedSubSystems map[string]bool          // If true, log in main log
 	SubSystems         map[string]*SystemConfig // SubSystem specific configs
+	IsText             bool                     // If true, log is in plain text, otherwise it is JSON
 	mutex              sync.Mutex
 }
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -61,12 +61,14 @@ func ContextWithLogSubSystem(ctx context.Context, subsystem string) context.Cont
 	return context.WithValue(ctx, subSystemKey, subsystem)
 }
 
-// Returns a context with the logging subsystem cleared. Used when a context is passed back from a subsystem.
+// Returns a context with the logging subsystem cleared. Used when a context is passed back from a
+//   subsystem.
 func ContextWithOutLogSubSystem(ctx context.Context) context.Context {
 	return context.WithValue(ctx, subSystemKey, nil)
 }
 
-// Returns a context with the logging subsystem cleared. Used when a context is passed back from a subsystem.
+// Returns a context with the logging subsystem cleared. Used when a context is passed back from a
+//   subsystem.
 func ContextWithLogTrace(ctx context.Context, trace string) context.Context {
 	return context.WithValue(ctx, traceKey, trace)
 }
@@ -163,7 +165,13 @@ func LogDepth(ctx context.Context, level Level, depth int, format string, values
 		// Log to subsystem specific config
 		subConfig, subExists := config.SubSystems[subsystem]
 		if subExists {
-			if err := subConfig.log(subsystem, level, depth, trace, format, values...); err != nil {
+			var err error
+			if config.IsText {
+				err = subConfig.logText(subsystem, level, depth, trace, format, values...)
+			} else {
+				err = subConfig.logJSON(subsystem, level, depth, trace, format, values...)
+			}
+			if err != nil {
 				return err
 			}
 		}
@@ -175,7 +183,11 @@ func LogDepth(ctx context.Context, level Level, depth int, format string, values
 	}
 
 	// Log to main config
-	return config.Main.log(subsystem, level, depth, trace, format, values...)
+	if config.IsText {
+		return config.Main.logText(subsystem, level, depth, trace, format, values...)
+	} else {
+		return config.Main.logJSON(subsystem, level, depth, trace, format, values...)
+	}
 }
 
 // Keys for context key/pairs

--- a/pkg/logger/system_config.go
+++ b/pkg/logger/system_config.go
@@ -81,7 +81,7 @@ type LogEntry struct {
 	File         string `json:"file,omitempty"`
 	Level        string `json:"level,omitempty"`
 	Trace        string `json:"trace,omitempty"`
-	Entry        string `json:"entry,omitempty"`
+	Message      string `json:"message,omitempty"`
 }
 
 // Logs a JSON entry based on the system config
@@ -157,7 +157,7 @@ func (config *SystemConfig) logJSON(system string, level Level, depth int, trace
 	}
 
 	// Append actual log entry
-	entry.Entry = fmt.Sprintf(format, values...)
+	entry.Message = fmt.Sprintf(format, values...)
 
 	// Convert to JSON
 	line, err := json.Marshal(&entry)

--- a/pkg/logger/system_config.go
+++ b/pkg/logger/system_config.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -72,8 +73,114 @@ func (config *SystemConfig) SetWriter(writer io.Writer) {
 	config.Output = writer
 }
 
-// Logs an entry based on the system config
-func (config *SystemConfig) log(system string, level Level, depth int, trace, format string, values ...interface{}) error {
+type LogEntry struct {
+	Date         string `json:"date,omitempty"`
+	Time         string `json:"time,omitempty"`
+	MicroSeconds string `json:"ms,omitempty"`
+	System       string `json:"system,omitempty"`
+	File         string `json:"file,omitempty"`
+	Level        string `json:"level,omitempty"`
+	Trace        string `json:"trace,omitempty"`
+	Entry        string `json:"entry,omitempty"`
+}
+
+// Logs a JSON entry based on the system config
+func (config *SystemConfig) logJSON(system string, level Level, depth int, trace, format string,
+	values ...interface{}) error {
+
+	if config.MinLevel > level {
+		return nil // Level is below minimum
+	}
+
+	// Create log entry
+	now := time.Now()
+
+	entry := LogEntry{}
+
+	// Append Date
+	if config.Format&IncludeDate != 0 {
+		year, month, day := now.Date()
+		entry.Date = fmt.Sprintf("%04d/%02d/%02d", year, month, day)
+	}
+
+	// Append Time
+	if config.Format&IncludeTime != 0 {
+		hour, min, sec := now.Clock()
+		entry.Time = fmt.Sprintf("%02d:%02d:%02d", hour, min, sec)
+	}
+
+	// Append microseconds
+	if config.Format&IncludeMicro != 0 {
+		entry.MicroSeconds = fmt.Sprintf("%06d", now.Nanosecond()/1e3)
+	}
+
+	// Append System
+	if config.Format&IncludeSystem != 0 {
+		entry.System = system
+	}
+
+	// Append File
+	if config.Format&IncludeFile != 0 {
+		_, file, line, ok := runtime.Caller(2 + depth) // Code of interest is 2 levels up in stack
+		if ok {
+			file = filepath.Base(file)
+		} else {
+			file = "???"
+			line = 0
+		}
+
+		entry.File = fmt.Sprintf("%s:%d", file, line)
+	}
+
+	// Append Level
+	if config.Format&IncludeLevel != 0 {
+		switch level {
+		case LevelDebug:
+			entry.Level = "debug"
+		case LevelVerbose:
+			entry.Level = "verbose"
+		case LevelInfo:
+			entry.Level = "info"
+		case LevelWarn:
+			entry.Level = "warn"
+		case LevelError:
+			entry.Level = "error"
+		case LevelFatal:
+			entry.Level = "fatal"
+		case LevelPanic:
+			entry.Level = "panic"
+		}
+	}
+
+	if len(trace) > 0 {
+		entry.Trace = trace
+	}
+
+	// Append actual log entry
+	entry.Entry = fmt.Sprintf(format, values...)
+
+	// Convert to JSON
+	line, err := json.Marshal(&entry)
+	if err != nil {
+		return err
+	}
+
+	// Write to output
+	_, err = config.Output.Write(append(line, '\n'))
+
+	if level == LevelFatal {
+		os.Exit(1)
+	}
+	if level == LevelPanic {
+		panic(entry)
+	}
+	return err
+}
+
+// Logs a text entry based on the system config
+func (config *SystemConfig) logText(system string, level Level, depth int, trace, format string,
+	values ...interface{}) error {
+
 	if config.MinLevel > level {
 		return nil // Level is below minimum
 	}

--- a/pkg/spynode/handlers/data/timeouts.go
+++ b/pkg/spynode/handlers/data/timeouts.go
@@ -41,9 +41,10 @@ func (state *State) CheckTimeouts() error {
 		state.restartCount = 0 // Clear restart count
 	}
 
-	if state.restartCount > maxRestarts {
-		return errors.New(fmt.Sprintf("Restarted %d seconds", headerTimeout))
-	}
+	// TODO This needs to stop the node
+	// if state.restartCount > maxRestarts {
+	// 	return errors.New(fmt.Sprintf("Restarted %d seconds", headerTimeout))
+	// }
 
 	return nil
 }

--- a/pkg/txbuilder/errors.go
+++ b/pkg/txbuilder/errors.go
@@ -50,6 +50,8 @@ func errorCodeString(code int) string {
 		return "Missing Private Key"
 	case ErrorCodeWrongScriptTemplate:
 		return "Wrong Script Template"
+	case ErrorCodeBelowDustValue:
+		return "Below Dust Value"
 	case ErrorCodeDuplicateInput:
 		return "Duplicate Input"
 	default:


### PR DESCRIPTION
Change default logging to JSON format.
Also add an environment variable to change it back to plain text.

Spynode max restarts doesn't work because it would need to stop to do any good, which I am not sure if we want. Now that it is disabled, spynode will just continue to attempt to connect to its trusted node forever. We can revisit it later.