### PR TITLE
Add retry functionality for AWS, RPC, and Spynode.

### DIFF
--- a/cmd/smartcontract/client/node.go
+++ b/cmd/smartcontract/client/node.go
@@ -63,16 +63,19 @@ func Context() context.Context {
 
 	// -------------------------------------------------------------------------
 	// Logging
-	os.MkdirAll(path.Dir(os.Getenv("CLIENT_LOG_FILE_PATH")), os.ModePerm)
-	logFileName := filepath.FromSlash(os.Getenv("CLIENT_LOG_FILE_PATH"))
-	logFile, err := os.OpenFile(logFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-	if err != nil {
-		fmt.Printf("Failed to open log file : %v\n", err)
-		return nil
+	logConfig := logger.NewDevelopmentConfig()
+
+	if len(os.Getenv("CLIENT_LOG_FILE_PATH")) > 0 {
+		os.MkdirAll(path.Dir(os.Getenv("CLIENT_LOG_FILE_PATH")), os.ModePerm)
+		logFileName := filepath.FromSlash(os.Getenv("CLIENT_LOG_FILE_PATH"))
+		logFile, err := os.OpenFile(logFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			fmt.Printf("Failed to open log file : %v\n", err)
+			return nil
+		}
+		logConfig.Main.SetWriter(io.MultiWriter(os.Stdout, logFile))
 	}
 
-	logConfig := logger.NewDevelopmentConfig()
-	logConfig.Main.SetWriter(io.MultiWriter(os.Stdout, logFile))
 	logConfig.Main.Format |= logger.IncludeSystem | logger.IncludeMicro
 	// logConfig.Main.MinLevel = logger.LevelDebug
 	logConfig.EnableSubSystem(spynode.SubSystem)

--- a/cmd/smartcontractd/bootstrap/bootstrap.go
+++ b/cmd/smartcontractd/bootstrap/bootstrap.go
@@ -60,8 +60,10 @@ func NewConfigFromEnv(ctx context.Context) *config.Config {
 
 func NewMasterDB(ctx context.Context, cfg *config.Config) *db.DB {
 	masterDB, err := db.New(&db.StorageConfig{
-		Bucket: cfg.Storage.Bucket,
-		Root:   cfg.Storage.Root,
+		Bucket:     cfg.Storage.Bucket,
+		Root:       cfg.Storage.Root,
+		MaxRetries: cfg.AWS.MaxRetries,
+		RetryDelay: cfg.AWS.RetryDelay,
 	})
 	if err != nil {
 		logger.Fatal(ctx, "Register DB : %s", err)

--- a/cmd/smartcontractd/main.go
+++ b/cmd/smartcontractd/main.go
@@ -35,17 +35,6 @@ func main() {
 	// -------------------------------------------------------------------------
 	// Logging
 
-	// os.MkdirAll(path.Dir(os.Getenv("LOG_FILE_PATH")), os.ModePerm)
-	// logFileName := filepath.FromSlash(os.Getenv("LOG_FILE_PATH"))
-	// logFile, err := os.OpenFile(logFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-	// if err != nil {
-	// 	fmt.Printf("Failed to open log file : %v\n", err)
-	// 	return
-	// }
-	// defer logFile.Close()
-
-	// ctx = node.ContextWithDevelopmentLogger(ctx, io.MultiWriter(os.Stdout, logFile))
-
 	ctx := bootstrap.NewContextWithDevelopmentLogger()
 
 	// -------------------------------------------------------------------------
@@ -89,6 +78,8 @@ func main() {
 	}
 
 	spyNode := spynode.NewNode(spyConfig, spyStorage)
+
+	spyNode.SetupRetry(cfg.SpyNode.MaxRetries, cfg.SpyNode.RetryDelay)
 
 	// -------------------------------------------------------------------------
 	// RPC Node

--- a/cmd/smartcontractd/main.go
+++ b/cmd/smartcontractd/main.go
@@ -70,8 +70,8 @@ func main() {
 
 	// -------------------------------------------------------------------------
 	// SPY Node
-	spyStorageConfig := storage.NewConfig(cfg.NodeStorage.Bucket,
-		cfg.NodeStorage.Root)
+	spyStorageConfig := storage.NewConfig(cfg.NodeStorage.Bucket, cfg.NodeStorage.Root)
+	spyStorageConfig.SetupRetry(cfg.AWS.MaxRetries, cfg.AWS.RetryDelay)
 
 	var spyStorage storage.Storage
 	if strings.ToLower(spyStorageConfig.Bucket) == "standalone" {

--- a/cmd/smartcontractd/main.go
+++ b/cmd/smartcontractd/main.go
@@ -93,9 +93,11 @@ func main() {
 	// -------------------------------------------------------------------------
 	// RPC Node
 	rpcConfig := &rpcnode.Config{
-		Host:     cfg.RpcNode.Host,
-		Username: cfg.RpcNode.Username,
-		Password: cfg.RpcNode.Password,
+		Host:       cfg.RpcNode.Host,
+		Username:   cfg.RpcNode.Username,
+		Password:   cfg.RpcNode.Password,
+		MaxRetries: cfg.RpcNode.MaxRetries,
+		RetryDelay: cfg.RpcNode.RetryDelay,
 	}
 
 	rpcNode, err := rpcnode.NewNode(rpcConfig)

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -27,6 +27,8 @@ type Config struct {
 		UntrustedNodes int    `default:"25" envconfig:"UNTRUSTED_NODES"`
 		SafeTxDelay    int    `default:"2000" envconfig:"SAFE_TX_DELAY"`
 		ShotgunCount   int    `default:"100" envconfig:"SHOTGUN_COUNT"`
+		MaxRetries     int    `default:"25" envconfig:"NODE_MAX_RETRIES"`
+		RetryDelay     int    `default:"5000" envconfig:"NODE_RETRY_DELAY"`
 	}
 	RpcNode struct {
 		Host       string `envconfig:"RPC_HOST"`

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -29,14 +29,18 @@ type Config struct {
 		ShotgunCount   int    `default:"100" envconfig:"SHOTGUN_COUNT"`
 	}
 	RpcNode struct {
-		Host     string `envconfig:"RPC_HOST"`
-		Username string `envconfig:"RPC_USERNAME"`
-		Password string `envconfig:"RPC_PASSWORD"`
+		Host       string `envconfig:"RPC_HOST"`
+		Username   string `envconfig:"RPC_USERNAME"`
+		Password   string `envconfig:"RPC_PASSWORD"`
+		MaxRetries int    `default:"10" envconfig:"RPC_MAX_RETRIES"`
+		RetryDelay int    `default:"2000" envconfig:"RPC_RETRY_DELAY"`
 	}
 	AWS struct {
 		Region          string `default:"ap-southeast-2" envconfig:"AWS_REGION" json:"AWS_REGION"`
 		AccessKeyID     string `envconfig:"AWS_ACCESS_KEY_ID" json:"AWS_ACCESS_KEY_ID"`
 		SecretAccessKey string `envconfig:"AWS_SECRET_ACCESS_KEY" json:"AWS_SECRET_ACCESS_KEY"`
+		MaxRetries      int    `default:"10" envconfig:"AWS_MAX_RETRIES"`
+		RetryDelay      int    `default:"2000" envconfig:"AWS_RETRY_DELAY"`
 	}
 	NodeStorage struct {
 		Bucket string `default:"standalone" envconfig:"NODE_STORAGE_BUCKET"`

--- a/internal/platform/db/db.go
+++ b/internal/platform/db/db.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/tokenized/smart-contract/pkg/storage"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 )

--- a/internal/platform/db/db.go
+++ b/internal/platform/db/db.go
@@ -33,8 +33,10 @@ type DB struct {
 // StorageConfig is geared towards "bucket" style storage, where you have a
 // specific root (the Bucket).
 type StorageConfig struct {
-	Bucket string
-	Root   string
+	Bucket     string
+	Root       string
+	MaxRetries int
+	RetryDelay int // Milliseconds between retries
 }
 
 // New returns a new DB value for use with document storage based on a

--- a/pkg/rpcnode/config.go
+++ b/pkg/rpcnode/config.go
@@ -8,13 +8,16 @@ type Config struct {
 	Host     string
 	Username string
 	Password string
+
+	// Retry attempts when calls fail.
+	MaxRetries int
+	RetryDelay int
 }
 
 // String returns a custom string representation.
 //
 // This is important so we don't log sensitive config values.
 func (c Config) String() string {
-	return fmt.Sprintf("{Host:%v Username:%v Password:%v}", c.Host,
-		c.Username,
-		"****")
+	return fmt.Sprintf("{Host:%v Username:%v Password:%v MaxRetries:%d RetryDelay:%d ms}", c.Host,
+		c.Username, "****", c.MaxRetries, c.RetryDelay)
 }

--- a/pkg/spynode/handlers/data/config.go
+++ b/pkg/spynode/handlers/data/config.go
@@ -17,8 +17,18 @@ type Config struct {
 	UntrustedCount int            // The number of untrusted nodes to run for double spend monitoring
 	SafeTxDelay    int            // Number of milliseconds without conflict before a tx is "safe"
 	ShotgunCount   int            // The number of nodes to attempt to send to when broadcasting
-	Lock           sync.Mutex     // Lock for config data
+
+	// Retry attempts when main connection fails.
+	MaxRetries int
+	RetryDelay int
+
+	Lock sync.Mutex // Lock for config data
 }
+
+const (
+	DefaultMaxRetries = 25
+	DefaultRetryDelay = 5000
+)
 
 // NewConfig returns a new Config populated from environment variables.
 func NewConfig(net bitcoin.Network, host, useragent, starthash string, untrustedNodes, safeDelay,
@@ -30,6 +40,8 @@ func NewConfig(net bitcoin.Network, host, useragent, starthash string, untrusted
 		UntrustedCount: untrustedNodes,
 		SafeTxDelay:    safeDelay,
 		ShotgunCount:   shotgunCount,
+		MaxRetries:     DefaultMaxRetries,
+		RetryDelay:     DefaultRetryDelay,
 	}
 
 	hash, err := bitcoin.NewHash32FromStr(starthash)

--- a/pkg/spynode/handlers/data/state.go
+++ b/pkg/spynode/handlers/data/state.go
@@ -25,7 +25,6 @@ type State struct {
 	blocksRequested    []*requestedBlock // Blocks that have been requested
 	blocksToRequest    []bitcoin.Hash32  // Blocks that need to be requested
 	pendingSync        bool              // The peer has notified us of all blocks. Now we just have to process to catch up.
-	restartCount       int               // Number of restarts since last clear
 	lock               sync.Mutex
 }
 
@@ -46,7 +45,6 @@ func NewState() *State {
 		blocksRequested:    make([]*requestedBlock, 0, maxRequestedBlocks),
 		blocksToRequest:    make([]bitcoin.Hash32, 0, 2000),
 		pendingSync:        false,
-		restartCount:       0,
 	}
 	return &result
 }
@@ -230,13 +228,6 @@ func (state *State) SetStartHeight(startHeight int) {
 	defer state.lock.Unlock()
 
 	state.startHeight = startHeight
-}
-
-func (state *State) LogRestart() {
-	state.lock.Lock()
-	defer state.lock.Unlock()
-
-	state.restartCount++
 }
 
 func (state *State) HeadersRequested() *time.Time {

--- a/pkg/spynode/handlers/data/timeouts.go
+++ b/pkg/spynode/handlers/data/timeouts.go
@@ -11,9 +11,6 @@ const (
 	handshakeTimeout = 30
 	headerTimeout    = 60
 	blockTimeout     = 600
-
-	// Maximum number of restarts allowed in a minute before stopping
-	maxRestarts = 5 // TODO This needs to stop the node
 )
 
 func (state *State) CheckTimeouts() error {
@@ -36,15 +33,6 @@ func (state *State) CheckTimeouts() error {
 				blockTimeout, blockRequest.hash.String()))
 		}
 	}
-
-	if state.restartCount > 0 && state.connectedTime != nil && now.Sub(*state.connectedTime).Seconds() > 60 {
-		state.restartCount = 0 // Clear restart count
-	}
-
-	// TODO This needs to stop the node
-	// if state.restartCount > maxRestarts {
-	// 	return errors.New(fmt.Sprintf("Restarted %d seconds", headerTimeout))
-	// }
 
 	return nil
 }

--- a/pkg/storage/config.go
+++ b/pkg/storage/config.go
@@ -5,6 +5,10 @@ import "fmt"
 const (
 	// DefaultMaxRetries is the number of retries for a write operation
 	DefaultMaxRetries = 4
+
+	// DefaultRetryDelay is the number of milliseconds to wait before attempting a retry after a
+	//   failure.
+	DefaultRetryDelay = 5000
 )
 
 // Config holds all configuration for the Storage.
@@ -15,6 +19,7 @@ type Config struct {
 	Bucket     string
 	Root       string
 	MaxRetries int
+	RetryDelay int
 }
 
 // NewConfig returns a new Config with AWS style options.
@@ -23,6 +28,7 @@ func NewConfig(bucket, root string) Config {
 		Bucket:     bucket,
 		Root:       root,
 		MaxRetries: DefaultMaxRetries,
+		RetryDelay: DefaultRetryDelay,
 	}
 }
 
@@ -32,8 +38,9 @@ func (c Config) String() string {
 		root = fmt.Sprintf("Root:%s", c.Root)
 	}
 
-	return fmt.Sprintf("{Bucket:%v %s MaxRetries:%v}",
+	return fmt.Sprintf("{Bucket:%v %s MaxRetries:%v RetryDelay:%v}",
 		c.Bucket,
 		root,
-		c.MaxRetries)
+		c.MaxRetries,
+		c.RetryDelay)
 }

--- a/pkg/storage/config.go
+++ b/pkg/storage/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	Bucket     string
 	Root       string
 	MaxRetries int
-	RetryDelay int
+	RetryDelay int // Milliseconds between retries
 }
 
 // NewConfig returns a new Config with AWS style options.
@@ -32,13 +32,18 @@ func NewConfig(bucket, root string) Config {
 	}
 }
 
+func (c *Config) SetupRetry(max, delay int) {
+	c.MaxRetries = max
+	c.RetryDelay = delay
+}
+
 func (c Config) String() string {
 	root := ""
 	if len(c.Root) > 0 {
 		root = fmt.Sprintf("Root:%s", c.Root)
 	}
 
-	return fmt.Sprintf("{Bucket:%v %s MaxRetries:%v RetryDelay:%v}",
+	return fmt.Sprintf("{Bucket:%v %s MaxRetries:%v RetryDelay:%v ms}",
 		c.Bucket,
 		root,
 		c.MaxRetries,

--- a/pkg/storage/s3_storage.go
+++ b/pkg/storage/s3_storage.go
@@ -7,11 +7,14 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/tokenized/smart-contract/pkg/logger"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/pkg/errors"
 )
 
 // S3Storage implements the Storage interface for interacting with AWS S3.
@@ -52,19 +55,28 @@ func (s S3Storage) Write(ctx context.Context,
 		Body:   bytes.NewReader(body),
 	}
 
-	if options != nil {
-		if options.TTL > 0 {
-			expiry := time.Now().Add(time.Duration(options.TTL) * time.Second)
-			poi.Expires = &expiry
+	var err error
+	for i := 0; i < s.Config.MaxRetries; i++ {
+		if options != nil {
+			if options.TTL > 0 {
+				expiry := time.Now().Add(time.Duration(options.TTL) * time.Second)
+				poi.Expires = &expiry
+			}
 		}
-	}
 
-	_, err := svc.PutObject(&poi)
+		_, err = svc.PutObject(&poi)
+		if err == nil {
+			break
+		}
+
+		logger.Error(ctx, "S3CallFailed to write to %v : %v", key, err)
+		time.Sleep(time.Duration(s.Config.RetryDelay) * time.Millisecond)
+	}
 
 	if err != nil {
-		return fmt.Errorf("Failed to write to %v : %v", key, err)
+		logger.Error(ctx, "S3CallAborted write to %v : %v", key, err)
+		return errors.Wrap(err, fmt.Sprintf("Failed to write to %v", key))
 	}
-
 	return nil
 }
 
@@ -72,27 +84,42 @@ func (s S3Storage) Write(ctx context.Context,
 func (s S3Storage) Read(ctx context.Context, key string) ([]byte, error) {
 	svc := s3.New(s.Session)
 
-	document, err := svc.GetObject(&s3.GetObjectInput{
-		Bucket: aws.String(s.Config.Bucket),
-		Key:    aws.String(key),
-	})
+	var err error
+	var document *s3.GetObjectOutput
+	var b []byte
+	for i := 0; i < s.Config.MaxRetries; i++ {
+		document, err = svc.GetObject(&s3.GetObjectInput{
+			Bucket: aws.String(s.Config.Bucket),
+			Key:    aws.String(key),
+		})
 
-	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			if aerr.Code() == s3.ErrCodeNoSuchKey {
-				// specifically handle the "not found" case
-				return nil, ErrNotFound
+		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				if aerr.Code() == s3.ErrCodeNoSuchKey {
+					// specifically handle the "not found" case
+					return nil, ErrNotFound
+				}
 			}
+
+			logger.Error(ctx, "S3CallFailed to read from %v : %v", key, err)
+			time.Sleep(time.Duration(s.Config.RetryDelay) * time.Millisecond)
+			continue
 		}
 
-		return nil, fmt.Errorf("Failed to read from %v : %v", key, err)
+		b, err = ioutil.ReadAll(document.Body)
+		if err != nil {
+			logger.Error(ctx, "S3CallFailed to read from %v : %v", key, err)
+			time.Sleep(time.Duration(s.Config.RetryDelay) * time.Millisecond)
+			continue
+		}
+
+		break
 	}
 
-	b, err := ioutil.ReadAll(document.Body)
 	if err != nil {
-		return nil, fmt.Errorf("Error reading body : %v", err)
+		logger.Error(ctx, "S3CallAborted read from %v : %v", key, err)
+		return nil, errors.Wrap(err, fmt.Sprintf("Failed to read from %v", key))
 	}
-
 	return b, nil
 }
 
@@ -105,18 +132,27 @@ func (s S3Storage) Remove(ctx context.Context, key string) error {
 		Key:    aws.String(key),
 	}
 
-	_, err := svc.DeleteObject(do)
-	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			if aerr.Code() == s3.ErrCodeNoSuchKey {
-				// specifically handle the "not found" case
-				return ErrNotFound
+	var err error
+	for i := 0; i < s.Config.MaxRetries; i++ {
+		_, err = svc.DeleteObject(do)
+		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				if aerr.Code() == s3.ErrCodeNoSuchKey {
+					// specifically handle the "not found" case
+					return ErrNotFound
+				}
 			}
-		}
 
-		return fmt.Errorf("Failed to delete object at %v : %v", key, err)
+			logger.Error(ctx, "S3CallFailed to delete object at %v : %v", key, err)
+			time.Sleep(time.Duration(s.Config.RetryDelay) * time.Millisecond)
+			continue
+		}
 	}
 
+	if err != nil {
+		logger.Error(ctx, "S3CallAborted delete object at %v : %v", key, err)
+		return errors.Wrap(err, fmt.Sprintf("Failed to delete object at %v", key))
+	}
 	return nil
 }
 
@@ -125,9 +161,21 @@ func (s S3Storage) Search(ctx context.Context,
 
 	path := query["path"]
 
-	keys, err := s.findKeys(ctx, path)
+	var err error
+	var keys []string
+	for i := 0; i < s.Config.MaxRetries; i++ {
+		keys, err = s.findKeys(ctx, path)
+		if err == nil {
+			break
+		}
+
+		logger.Error(ctx, "S3CallFailed to search %v : %v", path, err)
+		time.Sleep(time.Duration(s.Config.RetryDelay) * time.Millisecond)
+	}
+
 	if err != nil {
-		return nil, err
+		logger.Error(ctx, "S3CallAborted search %v : %v", path, err)
+		return nil, errors.Wrap(err, fmt.Sprintf("Failed to search %v", path))
 	}
 
 	svc := s3manager.NewDownloader(s.Session)
@@ -152,8 +200,19 @@ func (s S3Storage) Search(ctx context.Context,
 
 	iter := &s3manager.DownloadObjectsIterator{Objects: objects}
 
-	if err := svc.DownloadWithIterator(ctx, iter); err != nil {
-		return nil, err
+	for i := 0; i < s.Config.MaxRetries; i++ {
+		err = svc.DownloadWithIterator(ctx, iter)
+		if err == nil {
+			break
+		}
+
+		logger.Error(ctx, "S3CallFailed to download with iterator %v : %v", path, err)
+		time.Sleep(time.Duration(s.Config.RetryDelay) * time.Millisecond)
+	}
+
+	if err != nil {
+		logger.Error(ctx, "S3CallAborted download with iterator %v : %v", path, err)
+		return nil, errors.Wrap(err, fmt.Sprintf("Failed to download with iterator %v", path))
 	}
 
 	return buf.objects(), nil
@@ -162,9 +221,21 @@ func (s S3Storage) Search(ctx context.Context,
 func (s S3Storage) Clear(ctx context.Context, query map[string]string) error {
 	path := query["path"]
 
-	keys, err := s.findKeys(ctx, path)
+	var err error
+	var keys []string
+	for i := 0; i < s.Config.MaxRetries; i++ {
+		keys, err = s.findKeys(ctx, path)
+		if err == nil {
+			break
+		}
+
+		logger.Error(ctx, "S3CallFailed to search %v : %v", path, err)
+		time.Sleep(time.Duration(s.Config.RetryDelay) * time.Millisecond)
+	}
+
 	if err != nil {
-		return err
+		logger.Error(ctx, "S3CallAborted search %v : %v", path, err)
+		return errors.Wrap(err, fmt.Sprintf("Failed to search %v", path))
 	}
 
 	svc := s3manager.NewBatchDelete(s.Session)
@@ -186,15 +257,39 @@ func (s S3Storage) Clear(ctx context.Context, query map[string]string) error {
 
 	iter := &s3manager.DeleteObjectsIterator{Objects: objects}
 
-	if err := svc.Delete(ctx, iter); err != nil {
-		return err
+	for i := 0; i < s.Config.MaxRetries; i++ {
+		err = svc.Delete(ctx, iter)
+		if err == nil {
+			break
+		}
+
+		logger.Error(ctx, "S3CallFailed to delete %v : %v", path, err)
+		time.Sleep(time.Duration(s.Config.RetryDelay) * time.Millisecond)
+	}
+
+	if err != nil {
+		logger.Error(ctx, "S3CallAborted delete %v : %v", path, err)
+		return errors.Wrap(err, fmt.Sprintf("Failed to delete %v", path))
 	}
 
 	return nil
 }
 
 func (s S3Storage) List(ctx context.Context, path string) ([]string, error) {
-	return s.findKeys(ctx, path)
+	var err error
+	var keys []string
+	for i := 0; i < s.Config.MaxRetries; i++ {
+		keys, err = s.findKeys(ctx, path)
+		if err == nil {
+			return keys, nil
+		}
+
+		logger.Error(ctx, "S3CallFailed to search %v : %v", path, err)
+		time.Sleep(time.Duration(s.Config.RetryDelay) * time.Millisecond)
+	}
+
+	logger.Error(ctx, "S3CallAborted search %v : %v", path, err)
+	return nil, errors.Wrap(err, fmt.Sprintf("Failed to search %v", path))
 }
 
 func (s S3Storage) findKeys(ctx context.Context,


### PR DESCRIPTION
One note is that we could use the built-in AWS retry functionality. It has better logic to only retry for error codes that make sense and specific delay times for specific error codes as well, but it will be more difficult to get it to log the way we want for monitoring.