### PR TITLE
Spynode Fix

### DIFF
--- a/cmd/smartcontractd/bootstrap/bootstrap.go
+++ b/cmd/smartcontractd/bootstrap/bootstrap.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/tokenized/smart-contract/internal/holdings"
 	"github.com/tokenized/smart-contract/internal/platform/config"
@@ -29,9 +30,17 @@ func NewContextWithDevelopmentLogger() context.Context {
 			logger.Fatal(ctx, "Failed to open log file : %v\n", err)
 		}
 
-		ctx = node.ContextWithDevelopmentLogger(ctx, logFile, os.Getenv("LOG_FORMAT"))
+		if strings.ToUpper(os.Getenv("DEVELOPMENT")) == "TRUE" {
+			ctx = node.ContextWithDevelopmentLogger(ctx, logFile, os.Getenv("LOG_FORMAT"))
+		} else {
+			ctx = node.ContextWithProductionLogger(ctx, logFile, os.Getenv("LOG_FORMAT"))
+		}
 	} else {
-		ctx = node.ContextWithDevelopmentLogger(ctx, os.Stdout, os.Getenv("LOG_FORMAT"))
+		if strings.ToUpper(os.Getenv("DEVELOPMENT")) == "TRUE" {
+			ctx = node.ContextWithDevelopmentLogger(ctx, os.Stdout, os.Getenv("LOG_FORMAT"))
+		} else {
+			ctx = node.ContextWithProductionLogger(ctx, os.Stdout, os.Getenv("LOG_FORMAT"))
+		}
 	}
 
 	return ctx

--- a/pkg/spynode/handlers/data/mempool.go
+++ b/pkg/spynode/handlers/data/mempool.go
@@ -11,9 +11,9 @@ import (
 // MemPool is used for managing announced transactions that haven't confirmed yet.
 // The mempool is non-persistent and is mainly used to prevent duplicate tx requests.
 type MemPool struct {
-	txs      map[bitcoin.Hash32]*memPoolTx        // Lookup of block height by hash.
-	inputs   map[bitcoin.Hash32][]*bitcoin.Hash32 // Lookup by hash of outpoint. Used to find conflicting inputs.
-	requests map[bitcoin.Hash32]time.Time         // Transactions that have been requested
+	txs      map[bitcoin.Hash32]*memPoolTx       // Lookup of block height by hash.
+	inputs   map[bitcoin.Hash32][]bitcoin.Hash32 // Lookup by hash of outpoint. Used to find conflicting inputs.
+	requests map[bitcoin.Hash32]time.Time        // Transactions that have been requested
 	mutex    sync.Mutex
 }
 
@@ -21,7 +21,7 @@ type MemPool struct {
 func NewMemPool() *MemPool {
 	result := MemPool{
 		txs:      make(map[bitcoin.Hash32]*memPoolTx),
-		inputs:   make(map[bitcoin.Hash32][]*bitcoin.Hash32),
+		inputs:   make(map[bitcoin.Hash32][]bitcoin.Hash32),
 		requests: make(map[bitcoin.Hash32]time.Time),
 	}
 	return &result
@@ -32,25 +32,25 @@ func NewMemPool() *MemPool {
 // Returns:
 //   bool - True if we already have the tx
 //   bool - True if the tx should be requested
-func (memPool *MemPool) AddRequest(txid *bitcoin.Hash32) (bool, bool) {
+func (memPool *MemPool) AddRequest(txid bitcoin.Hash32) (bool, bool) {
 	memPool.mutex.Lock()
 	defer memPool.mutex.Unlock()
 
 	now := time.Now()
-	tx, exists := memPool.txs[*txid]
+	tx, exists := memPool.txs[txid]
 	if exists {
 		if len(tx.outPoints) > 0 {
 			return true, false // Already in the mempool
 		}
 	} else {
 		// Add tx
-		memPool.txs[*txid] = newMemPoolTx(now)
+		memPool.txs[txid] = newMemPoolTx(now)
 	}
 
-	requestTime, requested := memPool.requests[*txid]
+	requestTime, requested := memPool.requests[txid]
 	if !requested || now.Sub(requestTime).Seconds() > 3 {
 		// Tx has not been requested yet or the previous request is old
-		memPool.requests[*txid] = now
+		memPool.requests[txid] = now
 		return false, true
 	}
 
@@ -62,11 +62,11 @@ func (memPool *MemPool) AddRequest(txid *bitcoin.Hash32) (bool, bool) {
 //   []*bitcoin.Hash32 - list of conflicting transactions (not including this tx) if there are
 //     conflicts with inputs (double spends).
 //   bool - true if the tx isn't already in the mempool and was added
-func (memPool *MemPool) AddTransaction(tx *wire.MsgTx) ([]*bitcoin.Hash32, bool) {
+func (memPool *MemPool) AddTransaction(tx *wire.MsgTx) ([]bitcoin.Hash32, bool) {
 	memPool.mutex.Lock()
 	defer memPool.mutex.Unlock()
 
-	result := make([]*bitcoin.Hash32, 0)
+	result := []bitcoin.Hash32{}
 	hash := tx.TxHash()
 
 	memTx, exists := memPool.txs[*hash]
@@ -92,11 +92,10 @@ func (memPool *MemPool) AddTransaction(tx *wire.MsgTx) ([]*bitcoin.Hash32, bool)
 			// It is possible tx conflict on more than one input and we don't want duplicates in
 			//   the result list.
 			appendIfNotContained(result, list)
-			list = append(list, hash)
+			list = append(list, *hash)
 		} else {
 			// Create new list with only this tx hash
-			list := make([]*bitcoin.Hash32, 1)
-			list[0] = hash
+			list := []bitcoin.Hash32{*hash}
 			memPool.inputs[*outpointHash] = list
 		}
 	}
@@ -105,11 +104,11 @@ func (memPool *MemPool) AddTransaction(tx *wire.MsgTx) ([]*bitcoin.Hash32, bool)
 }
 
 // Appends the items in add to list if they are not already in list
-func appendIfNotContained(list []*bitcoin.Hash32, add []*bitcoin.Hash32) {
+func appendIfNotContained(list []bitcoin.Hash32, add []bitcoin.Hash32) {
 	for _, addHash := range add {
 		found := false
 		for _, hash := range list {
-			if *hash == *addHash {
+			if hash == addHash {
 				found = true
 				break
 			}
@@ -123,7 +122,7 @@ func appendIfNotContained(list []*bitcoin.Hash32, add []*bitcoin.Hash32) {
 
 // Removes a tx hash from the mempool
 // Returns true if the tx was in the mempool
-func (memPool *MemPool) RemoveTransaction(hash *bitcoin.Hash32) bool {
+func (memPool *MemPool) RemoveTransaction(hash bitcoin.Hash32) bool {
 	memPool.mutex.Lock()
 	defer memPool.mutex.Unlock()
 
@@ -132,11 +131,13 @@ func (memPool *MemPool) RemoveTransaction(hash *bitcoin.Hash32) bool {
 
 // Removes a tx hash from the mempool
 // Returns true if the tx was in the mempool
-func (memPool *MemPool) removeTransaction(hash *bitcoin.Hash32) bool {
-	tx, exists := memPool.txs[*hash]
+func (memPool *MemPool) removeTransaction(hash bitcoin.Hash32) bool {
+	tx, exists := memPool.txs[hash]
 	if exists {
 		// Remove outpoints
+		hadOutpoints := false
 		for _, outpoint := range tx.outPoints {
+			hadOutpoints = true
 			outpointHash := outpoint.OutpointHash()
 			otherHashes, exists := memPool.inputs[*outpointHash]
 			if exists { // It should always exist
@@ -155,9 +156,10 @@ func (memPool *MemPool) removeTransaction(hash *bitcoin.Hash32) bool {
 		}
 
 		// Remove tx
-		delete(memPool.txs, *hash)
+		delete(memPool.txs, hash)
+		return hadOutpoints
 	}
-	return exists
+	return false
 }
 
 // Returns true if the transaction is in the mempool
@@ -176,11 +178,11 @@ func (memPool *MemPool) TransactionExists(hash *bitcoin.Hash32) bool {
 // Returns txids of any transactions from the mempool with inputs that conflict with the specified
 //   transaction.
 // Also removes them from the mempool.
-func (memPool *MemPool) Conflicting(tx *wire.MsgTx) []*bitcoin.Hash32 {
+func (memPool *MemPool) Conflicting(tx *wire.MsgTx) []bitcoin.Hash32 {
 	memPool.mutex.Lock()
 	defer memPool.mutex.Unlock()
 
-	result := make([]*bitcoin.Hash32, 0, 1)
+	result := make([]bitcoin.Hash32, 0, 1)
 	// Check for conflicting inputs
 	for _, input := range tx.TxIn {
 		if list, exists := memPool.inputs[*input.PreviousOutPoint.OutpointHash()]; exists {

--- a/pkg/spynode/handlers/data/tx_tracker.go
+++ b/pkg/spynode/handlers/data/tx_tracker.go
@@ -76,7 +76,7 @@ func (tracker *TxTracker) Check(ctx context.Context, mempool *MemPool) ([]wire.M
 	response := []wire.Message{}
 	invRequest := wire.NewMsgGetData()
 	for txid, addedTime := range tracker.txids {
-		alreadyHave, shouldRequest := mempool.AddRequest(txid)
+		alreadyHave, shouldRequest := mempool.AddRequest(ctx, txid, false)
 		if alreadyHave {
 			delete(tracker.txids, txid) // Remove since we have received tx
 		} else if shouldRequest {

--- a/pkg/spynode/handlers/handlers.go
+++ b/pkg/spynode/handlers/handlers.go
@@ -83,8 +83,8 @@ type StateReady interface {
 func NewTrustedCommandHandlers(ctx context.Context, config data.Config, state *data.State,
 	peers *storage.PeerRepository, blockRepo *storage.BlockRepository, txRepo *storage.TxRepository,
 	reorgRepo *storage.ReorgRepository, tracker *data.TxTracker, memPool *data.MemPool,
-	confTxChannel *TxChannel, unconfTxChannel *TxChannel, listeners []Listener, txFilters []TxFilter,
-	blockProcessor BlockProcessor) map[string]CommandHandler {
+	confTxChannel *TxChannel, unconfTxChannel *TxChannel, txStateChannel *TxStateChannel,
+	listeners []Listener, txFilters []TxFilter, blockProcessor BlockProcessor) map[string]CommandHandler {
 
 	return map[string]CommandHandler{
 		wire.CmdPing:    NewPingHandler(),
@@ -92,10 +92,11 @@ func NewTrustedCommandHandlers(ctx context.Context, config data.Config, state *d
 		wire.CmdAddr:    NewAddressHandler(peers),
 		wire.CmdInv:     NewInvHandler(state, txRepo, tracker, memPool),
 		wire.CmdTx:      NewTXHandler(state, unconfTxChannel, memPool, txRepo, listeners, txFilters),
-		wire.CmdBlock: NewBlockHandler(state, confTxChannel, memPool, blockRepo, txRepo, listeners,
-			txFilters, blockProcessor),
-		wire.CmdHeaders: NewHeadersHandler(config, state, blockRepo, txRepo, reorgRepo, listeners),
-		wire.CmdReject:  NewRejectHandler(),
+		wire.CmdBlock: NewBlockHandler(state, confTxChannel, txStateChannel, memPool, blockRepo,
+			txRepo, listeners, txFilters, blockProcessor),
+		wire.CmdHeaders: NewHeadersHandler(config, state, txStateChannel, blockRepo, txRepo,
+			reorgRepo, listeners),
+		wire.CmdReject: NewRejectHandler(),
 	}
 }
 

--- a/pkg/spynode/handlers/handlers_test.go
+++ b/pkg/spynode/handlers/handlers_test.go
@@ -111,10 +111,13 @@ func TestHandlers(test *testing.T) {
 	unconfTxChannel := TxChannel{}
 	unconfTxChannel.Open(100)
 
+	txStateChannel := TxStateChannel{}
+	txStateChannel.Open(100)
+
 	// Create handlers
 	testHandlers := NewTrustedCommandHandlers(ctx, config, state, peerRepo, blockRepo, txRepo,
-		reorgRepo, txTracker, memPool, &confTxChannel, &unconfTxChannel, listeners, nil,
-		&testListener)
+		reorgRepo, txTracker, memPool, &confTxChannel, &unconfTxChannel, &txStateChannel, listeners,
+		nil, &testListener)
 
 	// Build a bunch of headers
 	blocks := make([]*wire.MsgBlock, 0, testBlockCount)
@@ -364,7 +367,7 @@ func (listener *TestListener) ProcessBlock(ctx context.Context, block *wire.MsgB
 		return err
 	}
 
-	listener.txTracker.Remove(ctx, txids)
+	listener.txTracker.RemoveList(ctx, txids)
 	return nil
 }
 

--- a/pkg/spynode/handlers/inventory.go
+++ b/pkg/spynode/handlers/inventory.go
@@ -47,8 +47,8 @@ func (handler *InvHandler) Handle(ctx context.Context, m wire.Message) ([]wire.M
 	for _, item := range msg.InvList {
 		switch item.Type {
 		case wire.InvTypeTx:
-			handler.txs.MarkTrusted(ctx, &item.Hash)
-			alreadyHave, shouldRequest := handler.memPool.AddRequest(&item.Hash)
+			handler.txs.MarkTrusted(ctx, item.Hash)
+			alreadyHave, shouldRequest := handler.memPool.AddRequest(item.Hash)
 			if !alreadyHave {
 				if shouldRequest {
 					// Request
@@ -64,7 +64,7 @@ func (handler *InvHandler) Handle(ctx context.Context, m wire.Message) ([]wire.M
 					}
 				} else {
 					// Track to ensure previous request is successful and if not, this node can request.
-					handler.tracker.Add(&item.Hash)
+					handler.tracker.Add(item.Hash)
 				}
 			}
 

--- a/pkg/spynode/handlers/inventory.go
+++ b/pkg/spynode/handlers/inventory.go
@@ -47,8 +47,7 @@ func (handler *InvHandler) Handle(ctx context.Context, m wire.Message) ([]wire.M
 	for _, item := range msg.InvList {
 		switch item.Type {
 		case wire.InvTypeTx:
-			handler.txs.MarkTrusted(ctx, item.Hash)
-			alreadyHave, shouldRequest := handler.memPool.AddRequest(item.Hash)
+			alreadyHave, shouldRequest := handler.memPool.AddRequest(ctx, item.Hash, true)
 			if !alreadyHave {
 				if shouldRequest {
 					// Request

--- a/pkg/spynode/handlers/storage/transactions.go
+++ b/pkg/spynode/handlers/storage/transactions.go
@@ -85,8 +85,12 @@ func (repo *TxRepository) Save(ctx context.Context) error {
 
 // Add a "relevant" tx id for a specified block
 // Height of -1 means unconfirmed
-// Returns true if the txid was not already in the repo for the specified height, and was added
-func (repo *TxRepository) Add(ctx context.Context, txid bitcoin.Hash32, trusted, safe bool, height int) (bool, error) {
+// Returns
+//   true if the txid was not already in the repo for the specified height, and was added
+//   true if the tx is safe, but was not before. This is so we know if we should notify of that state.
+func (repo *TxRepository) Add(ctx context.Context, txid bitcoin.Hash32, trusted, safe bool,
+	height int) (bool, bool, error) {
+
 	if height == -1 {
 		repo.unconfirmedLock.Lock()
 		defer repo.unconfirmedLock.Unlock()
@@ -94,14 +98,16 @@ func (repo *TxRepository) Add(ctx context.Context, txid bitcoin.Hash32, trusted,
 			if trusted {
 				tx.trusted = true
 			}
-			if safe {
+			newlySafe := false
+			if safe && !tx.safe {
 				tx.safe = true
+				newlySafe = true
 			}
-			return false, nil
+			return false, newlySafe, nil
 		}
 
 		repo.unconfirmed[txid] = newUnconfirmedTx(trusted, safe)
-		return true, nil
+		return true, safe, nil
 	}
 
 	path := repo.buildPath(height)
@@ -112,16 +118,16 @@ func (repo *TxRepository) Add(ctx context.Context, txid bitcoin.Hash32, trusted,
 	data, err := repo.store.Read(ctx, path)
 	if err == storage.ErrNotFound {
 		// Create new tx block file with only one hash
-		return true, repo.store.Write(ctx, path, txid[:], nil)
+		return true, false, repo.store.Write(ctx, path, txid[:], nil)
 	}
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 
 	// Check for already existing
 	for i := 0; i < len(data); i += bitcoin.Hash32Size {
 		if bytes.Equal(data[i:i+bitcoin.Hash32Size], txid[:]) {
-			return false, nil
+			return false, false, nil
 		}
 	}
 
@@ -129,7 +135,7 @@ func (repo *TxRepository) Add(ctx context.Context, txid bitcoin.Hash32, trusted,
 	newData := make([]byte, len(data)+bitcoin.Hash32Size)
 	copy(newData, data) // Copy in previous data
 	copy(newData[len(data):], txid[:])
-	return true, repo.store.Write(ctx, path, newData, nil)
+	return true, false, repo.store.Write(ctx, path, newData, nil)
 }
 
 // Remove a "relevant" tx id for a specified block

--- a/pkg/spynode/handlers/storage/transactions_test.go
+++ b/pkg/spynode/handlers/storage/transactions_test.go
@@ -38,7 +38,7 @@ func TestTransactions(test *testing.T) {
 	repo.ClearBlock(ctx, testBlockHeight)
 
 	for i, hash := range txs {
-		if _, err := repo.Add(ctx, hash, true, true, testBlockHeight); err != nil {
+		if _, _, err := repo.Add(ctx, hash, true, true, testBlockHeight); err != nil {
 			test.Errorf("Failed to add tx %d : %v", i, err)
 		}
 	}

--- a/pkg/spynode/handlers/storage/unconfirmed.go
+++ b/pkg/spynode/handlers/storage/unconfirmed.go
@@ -34,11 +34,11 @@ func (repo *TxRepository) MarkUnsafe(ctx context.Context, txid bitcoin.Hash32) (
 
 // Mark an unconfirmed tx as being verified by a trusted node.
 // Returns true if the tx was marked
-func (repo *TxRepository) MarkTrusted(ctx context.Context, txid *bitcoin.Hash32) (bool, error) {
+func (repo *TxRepository) MarkTrusted(ctx context.Context, txid bitcoin.Hash32) (bool, error) {
 	repo.unconfirmedLock.Lock()
 	defer repo.unconfirmedLock.Unlock()
 
-	if tx, exists := repo.unconfirmed[*txid]; exists {
+	if tx, exists := repo.unconfirmed[txid]; exists && !tx.trusted {
 		logger.Verbose(ctx, "Tx marked trusted : %s", txid.String())
 		tx.time = time.Now() // Reset so the "safe" delay is from when the trusted node verified.
 		tx.trusted = true

--- a/pkg/spynode/handlers/storage/unconfirmed.go
+++ b/pkg/spynode/handlers/storage/unconfirmed.go
@@ -20,7 +20,7 @@ var (
 )
 
 // Mark an unconfirmed tx as unsafe
-// Returns true if the tx was marked
+// Returns true if the tx was marked relevant
 func (repo *TxRepository) MarkUnsafe(ctx context.Context, txid bitcoin.Hash32) (bool, error) {
 	repo.unconfirmedLock.Lock()
 	defer repo.unconfirmedLock.Unlock()
@@ -33,7 +33,7 @@ func (repo *TxRepository) MarkUnsafe(ctx context.Context, txid bitcoin.Hash32) (
 }
 
 // Mark an unconfirmed tx as being verified by a trusted node.
-// Returns true if the tx was marked
+// Returns true if the tx was marked relevant
 func (repo *TxRepository) MarkTrusted(ctx context.Context, txid bitcoin.Hash32) (bool, error) {
 	repo.unconfirmedLock.Lock()
 	defer repo.unconfirmedLock.Unlock()

--- a/pkg/spynode/handlers/untrusted_inventory.go
+++ b/pkg/spynode/handlers/untrusted_inventory.go
@@ -44,7 +44,7 @@ func (handler *UntrustedInvHandler) Handle(ctx context.Context, m wire.Message) 
 	for _, item := range msg.InvList {
 		switch item.Type {
 		case wire.InvTypeTx:
-			alreadyHave, shouldRequest := handler.memPool.AddRequest(&item.Hash)
+			alreadyHave, shouldRequest := handler.memPool.AddRequest(item.Hash)
 			if !alreadyHave {
 				if shouldRequest {
 					// Request
@@ -60,7 +60,7 @@ func (handler *UntrustedInvHandler) Handle(ctx context.Context, m wire.Message) 
 					}
 				} else {
 					// Track to ensure previous request is successful and if not, this node can request.
-					handler.tracker.Add(&item.Hash)
+					handler.tracker.Add(item.Hash)
 				}
 			}
 

--- a/pkg/spynode/handlers/untrusted_inventory.go
+++ b/pkg/spynode/handlers/untrusted_inventory.go
@@ -44,7 +44,7 @@ func (handler *UntrustedInvHandler) Handle(ctx context.Context, m wire.Message) 
 	for _, item := range msg.InvList {
 		switch item.Type {
 		case wire.InvTypeTx:
-			alreadyHave, shouldRequest := handler.memPool.AddRequest(item.Hash)
+			alreadyHave, shouldRequest := handler.memPool.AddRequest(ctx, item.Hash, false)
 			if !alreadyHave {
 				if shouldRequest {
 					// Request

--- a/pkg/spynode/handlers/untrusted_transaction.go
+++ b/pkg/spynode/handlers/untrusted_transaction.go
@@ -45,6 +45,6 @@ func (handler *UntrustedTXHandler) Handle(ctx context.Context, m wire.Message) (
 		return nil, nil
 	}
 
-	handler.txChannel.Add(&TxData{Msg: msg, Trusted: false, ConfirmedHeight: -1})
+	handler.txChannel.Add(TxData{Msg: msg, Trusted: false, ConfirmedHeight: -1})
 	return nil, nil
 }

--- a/pkg/spynode/handlers/untrusted_transaction.go
+++ b/pkg/spynode/handlers/untrusted_transaction.go
@@ -2,12 +2,11 @@ package handlers
 
 import (
 	"context"
+	"errors"
 
 	"github.com/tokenized/smart-contract/pkg/spynode/handlers/data"
 	"github.com/tokenized/smart-contract/pkg/spynode/handlers/storage"
 	"github.com/tokenized/smart-contract/pkg/wire"
-
-	"github.com/pkg/errors"
 )
 
 // TXHandler exists to handle the tx command.

--- a/pkg/spynode/node.go
+++ b/pkg/spynode/node.go
@@ -47,6 +47,7 @@ type Node struct {
 	addresses       map[string]time.Time               // Recently used peer addresses
 	confTxChannel   handlers.TxChannel                 // Channel for directly handled txs so they don't lock the calling thread
 	unconfTxChannel handlers.TxChannel                 // Channel for directly handled txs so they don't lock the calling thread
+	txStateChannel  handlers.TxStateChannel            // Channel for tx states so they are in one thread
 	broadcastLock   sync.Mutex
 	broadcastTxs    []TxCount // Txs to transmit to nodes upon connection
 	needsRestart    bool
@@ -124,7 +125,7 @@ func (node *Node) load(ctx context.Context) error {
 
 	node.handlers = handlers.NewTrustedCommandHandlers(ctx, node.config, node.state, node.peers,
 		node.blocks, node.txs, node.reorgs, node.txTracker, node.memPool, &node.confTxChannel,
-		&node.unconfTxChannel, node.listeners, node.txFilters, node)
+		&node.unconfTxChannel, &node.txStateChannel, node.listeners, node.txFilters, node)
 	return nil
 }
 
@@ -163,44 +164,57 @@ func (node *Node) Run(ctx context.Context) error {
 		node.outgoing = make(chan wire.Message, 100)
 		node.confTxChannel.Open(100)
 		node.unconfTxChannel.Open(100)
+		node.txStateChannel.Open(1000)
 
 		// Queue version message to start handshake
 		version := buildVersionMsg(node.config.UserAgent, int32(node.blocks.LastHeight()))
 		node.outgoing <- version
 
 		wg := sync.WaitGroup{}
-		wg.Add(7)
 
+		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			node.monitorIncoming(ctx)
 			logger.Debug(ctx, "Monitor incoming finished")
 		}()
 
+		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			node.monitorRequestTimeouts(ctx)
 			logger.Debug(ctx, "Monitor request timeouts finished")
 		}()
 
+		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			node.sendOutgoing(ctx)
 			logger.Debug(ctx, "Send outgoing finished")
 		}()
 
+		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			node.processConfirmedTxs(ctx)
 			logger.Debug(ctx, "Process confirmed txs finished")
 		}()
 
+		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			node.processUnconfirmedTxs(ctx)
-			logger.Debug(ctx, "Process uncofirmed txs finished")
+			logger.Debug(ctx, "Process unconfirmed txs finished")
 		}()
 
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			node.processTxStates(ctx)
+			logger.Debug(ctx, "Process tx states finished")
+		}()
+
+		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			node.checkTxDelays(ctx)
@@ -208,9 +222,9 @@ func (node *Node) Run(ctx context.Context) error {
 		}()
 
 		if node.config.UntrustedCount == 0 {
-			wg.Done()
 			logger.Debug(ctx, "Monitor untrusted not started")
 		} else {
+			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				node.monitorUntrustedNodes(ctx)
@@ -289,6 +303,7 @@ func (node *Node) requestStop(ctx context.Context) error {
 	}
 	node.confTxChannel.Close()
 	node.unconfTxChannel.Close()
+	node.txStateChannel.Close()
 	if node.connection != nil {
 		node.connection.Close()
 	}
@@ -448,11 +463,11 @@ func (node *Node) ShotgunTransmitTx(ctx context.Context, tx *wire.MsgTx, sendCou
 // HandleTx processes a tx through spynode as if it came from the network.
 // Used to feed "response" txs directly back through spynode.
 func (node *Node) HandleTx(ctx context.Context, tx *wire.MsgTx) error {
-	return node.unconfTxChannel.Add(&handlers.TxData{Msg: tx, Trusted: true, Safe: true,
+	return node.unconfTxChannel.Add(handlers.TxData{Msg: tx, Trusted: true, Safe: true,
 		ConfirmedHeight: -1})
 }
 
-func (node *Node) processConfirmedTx(ctx context.Context, tx *handlers.TxData) error {
+func (node *Node) processConfirmedTx(ctx context.Context, tx handlers.TxData) error {
 	hash := tx.Msg.TxHash()
 
 	if tx.ConfirmedHeight == -1 {
@@ -461,28 +476,26 @@ func (node *Node) processConfirmedTx(ctx context.Context, tx *handlers.TxData) e
 
 	// Send full tx to listener if we aren't in sync yet and don't have a populated mempool.
 	// Or if it isn't in the mempool (not sent to listener yet).
-	var err error
 	marked := false
-	if !tx.Relevant { // Full tx hasn't been sent to listener yet
-		if handlers.MatchesFilter(ctx, tx.Msg, node.txFilters) {
-			var mark bool
-			for _, listener := range node.listeners {
-				mark, _ = listener.HandleTx(ctx, tx.Msg)
-				if mark {
-					marked = true
-				}
+	if handlers.MatchesFilter(ctx, tx.Msg, node.txFilters) {
+		var mark bool
+		for _, listener := range node.listeners {
+			mark, _ = listener.HandleTx(ctx, tx.Msg)
+			if mark {
+				marked = true
 			}
 		}
 	}
 
-	if marked || tx.Relevant {
+	if marked {
 		// Notify of confirm
-		for _, listener := range node.listeners {
-			listener.HandleTxState(ctx, handlers.ListenerMsgTxStateConfirm, *hash)
-		}
+		node.txStateChannel.Add(handlers.TxState{
+			handlers.ListenerMsgTxStateConfirm,
+			*hash,
+		})
 
 		// Add to txs for block
-		if _, err = node.txs.Add(ctx, *hash, tx.Trusted, tx.Safe, tx.ConfirmedHeight); err != nil {
+		if _, err := node.txs.Add(ctx, *hash, tx.Trusted, tx.Safe, tx.ConfirmedHeight); err != nil {
 			return err
 		}
 	}
@@ -490,12 +503,14 @@ func (node *Node) processConfirmedTx(ctx context.Context, tx *handlers.TxData) e
 	return nil
 }
 
-func (node *Node) processUnconfirmedTx(ctx context.Context, tx *handlers.TxData) error {
+func (node *Node) processUnconfirmedTx(ctx context.Context, tx handlers.TxData) error {
 	hash := tx.Msg.TxHash()
 
 	if tx.ConfirmedHeight != -1 {
 		return errors.New("Process unconfirmed tx with height")
 	}
+
+	node.txTracker.Remove(ctx, *hash)
 
 	// The mempool is needed to track which transactions have been sent to listeners and to check
 	//   for attempted double spends.
@@ -508,14 +523,15 @@ func (node *Node) processUnconfirmedTx(ctx context.Context, tx *handlers.TxData)
 		logger.Warn(ctx, "Found %d conflicts with %s", len(conflicts), hash)
 		// Notify of attempted double spend
 		for _, conflict := range conflicts {
-			marked, err := node.txs.MarkUnsafe(ctx, *conflict)
+			marked, err := node.txs.MarkUnsafe(ctx, conflict)
 			if err != nil {
 				return errors.Wrap(err, "Failed to check tx repo")
 			}
 			if marked { // Only send for txs that previously matched filters.
-				for _, listener := range node.listeners {
-					listener.HandleTxState(ctx, handlers.ListenerMsgTxStateUnsafe, *conflict)
-				}
+				node.txStateChannel.Add(handlers.TxState{
+					handlers.ListenerMsgTxStateUnsafe,
+					conflict,
+				})
 			}
 		}
 	}
@@ -535,32 +551,34 @@ func (node *Node) processUnconfirmedTx(ctx context.Context, tx *handlers.TxData)
 		return nil // Filter out
 	}
 	if tx.Trusted {
-		logger.Verbose(ctx, "Trusted tx added : %s", hash.String())
+		logger.Debug(ctx, "Trusted tx added : %s", hash.String())
 	} else {
-		logger.Verbose(ctx, "Untrusted tx added : %s", hash.String())
+		logger.Debug(ctx, "Untrusted tx added : %s", hash.String())
 	}
 
 	// Notify of new tx
 	marked := false
-	var mark bool
 	for _, listener := range node.listeners {
-		mark, _ = listener.HandleTx(ctx, tx.Msg)
-		if mark {
+		if mark, _ := listener.HandleTx(ctx, tx.Msg); mark {
 			marked = true
 		}
 	}
 
 	if marked {
+		logger.Verbose(ctx, "Tx is marked : %s", hash.String())
+
 		// Notify of conflicting txs
 		if len(conflicts) > 0 {
 			node.txs.MarkUnsafe(ctx, *hash)
-			for _, listener := range node.listeners {
-				listener.HandleTxState(ctx, handlers.ListenerMsgTxStateUnsafe, *hash)
-			}
+			node.txStateChannel.Add(handlers.TxState{
+				handlers.ListenerMsgTxStateUnsafe,
+				*hash,
+			})
 		} else if tx.Safe {
-			for _, listener := range node.listeners {
-				listener.HandleTxState(ctx, handlers.ListenerMsgTxStateSafe, *hash)
-			}
+			node.txStateChannel.Add(handlers.TxState{
+				handlers.ListenerMsgTxStateSafe,
+				*hash,
+			})
 		}
 	} else {
 		// Remove from tx repository
@@ -592,6 +610,15 @@ func (node *Node) processConfirmedTxs(ctx context.Context) {
 				tx.Msg.TxHash().String())
 			node.requestStop(ctx)
 			break
+		}
+	}
+}
+
+// processhandlers.TxStates pulls txs from the tx state channel and processes them.
+func (node *Node) processTxStates(ctx context.Context) {
+	for txState := range node.txStateChannel.Channel {
+		for _, listener := range node.listeners {
+			listener.HandleTxState(ctx, txState.MsgType, txState.TxId)
 		}
 	}
 }
@@ -658,7 +685,7 @@ func (node *Node) ProcessBlock(ctx context.Context, block *wire.MsgBlock) error 
 		return err
 	}
 
-	node.txTracker.Remove(ctx, txids)
+	node.txTracker.RemoveList(ctx, txids)
 
 	node.untrustedLock.Lock()
 	defer node.untrustedLock.Unlock()
@@ -877,9 +904,10 @@ func (node *Node) checkTxDelays(ctx context.Context) {
 		}
 
 		for _, txid := range txids {
-			for _, listener := range node.listeners {
-				listener.HandleTxState(ctx, handlers.ListenerMsgTxStateSafe, txid)
-			}
+			node.txStateChannel.Add(handlers.TxState{
+				handlers.ListenerMsgTxStateSafe,
+				txid,
+			})
 		}
 	}
 }

--- a/pkg/spynode/node.go
+++ b/pkg/spynode/node.go
@@ -495,7 +495,7 @@ func (node *Node) processConfirmedTx(ctx context.Context, tx handlers.TxData) er
 		})
 
 		// Add to txs for block
-		if _, err := node.txs.Add(ctx, *hash, tx.Trusted, tx.Safe, tx.ConfirmedHeight); err != nil {
+		if _, _, err := node.txs.Add(ctx, *hash, tx.Trusted, tx.Safe, tx.ConfirmedHeight); err != nil {
 			return err
 		}
 	}
@@ -523,49 +523,55 @@ func (node *Node) processUnconfirmedTx(ctx context.Context, tx handlers.TxData) 
 		logger.Warn(ctx, "Found %d conflicts with %s", len(conflicts), hash)
 		// Notify of attempted double spend
 		for _, conflict := range conflicts {
-			marked, err := node.txs.MarkUnsafe(ctx, conflict)
+			isRelevant, err := node.txs.MarkUnsafe(ctx, conflict)
 			if err != nil {
 				return errors.Wrap(err, "Failed to check tx repo")
 			}
-			if marked { // Only send for txs that previously matched filters.
-				node.txStateChannel.Add(handlers.TxState{
-					handlers.ListenerMsgTxStateUnsafe,
-					conflict,
-				})
+			if !isRelevant {
+				continue // Only send for txs that previously matched filters.
 			}
+
+			node.txStateChannel.Add(handlers.TxState{
+				handlers.ListenerMsgTxStateUnsafe,
+				conflict,
+			})
 		}
 	}
 
 	// We have to succesfully add to tx repo because it is protected by a lock and will prevent
 	//   processing the same tx twice at the same time.
-	if added, err := node.txs.Add(ctx, *hash, tx.Trusted, tx.Safe, -1); err != nil {
+	var newlySafe bool
+	var err error
+	if added, newlySafe, err = node.txs.Add(ctx, *hash, tx.Trusted, tx.Safe, -1); err != nil {
 		return errors.Wrap(err, "Failed to add to tx repo")
-	} else if !added {
-		return nil // Already seen
 	}
 
-	if !handlers.MatchesFilter(ctx, tx.Msg, node.txFilters) {
-		if _, err := node.txs.Remove(ctx, hash, -1); err != nil {
-			return errors.Wrap(err, "Failed to remove from tx repo")
+	isRelevant := false
+	if added {
+		if !handlers.MatchesFilter(ctx, tx.Msg, node.txFilters) {
+			if _, err := node.txs.Remove(ctx, hash, -1); err != nil {
+				return errors.Wrap(err, "Failed to remove from tx repo")
+			}
+			return nil // Filter out
 		}
-		return nil // Filter out
-	}
-	if tx.Trusted {
-		logger.Debug(ctx, "Trusted tx added : %s", hash.String())
+		if tx.Trusted {
+			logger.Debug(ctx, "Trusted tx added : %s", hash.String())
+		} else {
+			logger.Debug(ctx, "Untrusted tx added : %s", hash.String())
+		}
+
+		// Notify of new tx
+		for _, listener := range node.listeners {
+			if rel, _ := listener.HandleTx(ctx, tx.Msg); rel {
+				isRelevant = true
+			}
+		}
 	} else {
-		logger.Debug(ctx, "Untrusted tx added : %s", hash.String())
+		isRelevant = true // was already seen and marked relevant
 	}
 
-	// Notify of new tx
-	marked := false
-	for _, listener := range node.listeners {
-		if mark, _ := listener.HandleTx(ctx, tx.Msg); mark {
-			marked = true
-		}
-	}
-
-	if marked {
-		logger.Verbose(ctx, "Tx is marked : %s", hash.String())
+	if isRelevant {
+		logger.Verbose(ctx, "Tx is relevant : %s", hash.String())
 
 		// Notify of conflicting txs
 		if len(conflicts) > 0 {
@@ -574,7 +580,7 @@ func (node *Node) processUnconfirmedTx(ctx context.Context, tx handlers.TxData) 
 				handlers.ListenerMsgTxStateUnsafe,
 				*hash,
 			})
-		} else if tx.Safe {
+		} else if (added && tx.Safe) || newlySafe {
 			node.txStateChannel.Add(handlers.TxState{
 				handlers.ListenerMsgTxStateSafe,
 				*hash,

--- a/pkg/spynode/node.go
+++ b/pkg/spynode/node.go
@@ -176,59 +176,59 @@ func (node *Node) Run(ctx context.Context) error {
 		go func() {
 			defer wg.Done()
 			node.monitorIncoming(ctx)
-			logger.Debug(ctx, "Monitor incoming finished")
+			logger.Verbose(ctx, "Monitor incoming finished")
 		}()
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			node.monitorRequestTimeouts(ctx)
-			logger.Debug(ctx, "Monitor request timeouts finished")
+			logger.Verbose(ctx, "Monitor request timeouts finished")
 		}()
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			node.sendOutgoing(ctx)
-			logger.Debug(ctx, "Send outgoing finished")
+			logger.Verbose(ctx, "Send outgoing finished")
 		}()
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			node.processConfirmedTxs(ctx)
-			logger.Debug(ctx, "Process confirmed txs finished")
+			logger.Verbose(ctx, "Process confirmed txs finished")
 		}()
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			node.processUnconfirmedTxs(ctx)
-			logger.Debug(ctx, "Process unconfirmed txs finished")
+			logger.Verbose(ctx, "Process unconfirmed txs finished")
 		}()
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			node.processTxStates(ctx)
-			logger.Debug(ctx, "Process tx states finished")
+			logger.Verbose(ctx, "Process tx states finished")
 		}()
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			node.checkTxDelays(ctx)
-			logger.Debug(ctx, "Check tx delays finished")
+			logger.Verbose(ctx, "Check tx delays finished")
 		}()
 
 		if node.config.UntrustedCount == 0 {
-			logger.Debug(ctx, "Monitor untrusted not started")
+			logger.Verbose(ctx, "Monitor untrusted not started")
 		} else {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				node.monitorUntrustedNodes(ctx)
-				logger.Debug(ctx, "Monitor untrusted finished")
+				logger.Verbose(ctx, "Monitor untrusted finished")
 			}()
 		}
 
@@ -273,6 +273,13 @@ func (node *Node) isStopping() bool {
 // Stop closes the connection and causes Run() to return.
 func (node *Node) Stop(ctx context.Context) error {
 	ctx = logger.ContextWithLogSubSystem(ctx, SubSystem)
+	node.lock.Lock()
+	done := node.stopped
+	node.lock.Unlock()
+	if done {
+		return nil
+	}
+
 	node.hardStop = true
 	err := node.requestStop(ctx)
 	count := 0
@@ -476,18 +483,16 @@ func (node *Node) processConfirmedTx(ctx context.Context, tx handlers.TxData) er
 
 	// Send full tx to listener if we aren't in sync yet and don't have a populated mempool.
 	// Or if it isn't in the mempool (not sent to listener yet).
-	marked := false
+	isRelevant := false
 	if handlers.MatchesFilter(ctx, tx.Msg, node.txFilters) {
-		var mark bool
 		for _, listener := range node.listeners {
-			mark, _ = listener.HandleTx(ctx, tx.Msg)
-			if mark {
-				marked = true
+			if rel, _ := listener.HandleTx(ctx, tx.Msg); rel {
+				isRelevant = true
 			}
 		}
 	}
 
-	if marked {
+	if isRelevant {
 		// Notify of confirm
 		node.txStateChannel.Add(handlers.TxState{
 			handlers.ListenerMsgTxStateConfirm,
@@ -514,9 +519,18 @@ func (node *Node) processUnconfirmedTx(ctx context.Context, tx handlers.TxData) 
 
 	// The mempool is needed to track which transactions have been sent to listeners and to check
 	//   for attempted double spends.
-	conflicts, added := node.memPool.AddTransaction(tx.Msg)
+	conflicts, trusted, added := node.memPool.AddTransaction(ctx, tx.Msg, tx.Trusted)
 	if !added {
 		return nil // Already saw this tx
+	}
+
+	logger.Debug(ctx, "Tx mempool (added %t) (flagged trusted %t) (received trusted %t) : %s",
+		added, trusted, tx.Trusted, hash.String())
+
+	if trusted {
+		// Was marked trusted in the mempool by a tx inventory from the trusted node.
+		// tx.Trusted means the tx itself was received from the trusted node.
+		tx.Trusted = trusted
 	}
 
 	if len(conflicts) > 0 {
@@ -540,57 +554,54 @@ func (node *Node) processUnconfirmedTx(ctx context.Context, tx handlers.TxData) 
 
 	// We have to succesfully add to tx repo because it is protected by a lock and will prevent
 	//   processing the same tx twice at the same time.
-	var newlySafe bool
-	var err error
-	if added, newlySafe, err = node.txs.Add(ctx, *hash, tx.Trusted, tx.Safe, -1); err != nil {
+	added, newlySafe, err := node.txs.Add(ctx, *hash, tx.Trusted, tx.Safe, -1)
+	if err != nil {
 		return errors.Wrap(err, "Failed to add to tx repo")
 	}
+	if !added {
+		return nil // tx already processed
+	}
+
+	logger.Debug(ctx, "Tx repo (added %t) (newly safe %t) : %s", added, newlySafe, hash.String())
 
 	isRelevant := false
-	if added {
-		if !handlers.MatchesFilter(ctx, tx.Msg, node.txFilters) {
-			if _, err := node.txs.Remove(ctx, hash, -1); err != nil {
-				return errors.Wrap(err, "Failed to remove from tx repo")
-			}
-			return nil // Filter out
+	if !handlers.MatchesFilter(ctx, tx.Msg, node.txFilters) {
+		if _, err := node.txs.Remove(ctx, *hash, -1); err != nil {
+			return errors.Wrap(err, "Failed to remove from tx repo")
 		}
-		if tx.Trusted {
-			logger.Debug(ctx, "Trusted tx added : %s", hash.String())
-		} else {
-			logger.Debug(ctx, "Untrusted tx added : %s", hash.String())
-		}
+		return nil // Filter out
+	}
 
-		// Notify of new tx
-		for _, listener := range node.listeners {
-			if rel, _ := listener.HandleTx(ctx, tx.Msg); rel {
+	// Notify of new tx
+	for _, listener := range node.listeners {
+		if rel, _ := listener.HandleTx(ctx, tx.Msg); rel {
+			if !isRelevant {
 				isRelevant = true
 			}
 		}
-	} else {
-		isRelevant = true // was already seen and marked relevant
 	}
 
-	if isRelevant {
-		logger.Verbose(ctx, "Tx is relevant : %s", hash.String())
-
-		// Notify of conflicting txs
-		if len(conflicts) > 0 {
-			node.txs.MarkUnsafe(ctx, *hash)
-			node.txStateChannel.Add(handlers.TxState{
-				handlers.ListenerMsgTxStateUnsafe,
-				*hash,
-			})
-		} else if (added && tx.Safe) || newlySafe {
-			node.txStateChannel.Add(handlers.TxState{
-				handlers.ListenerMsgTxStateSafe,
-				*hash,
-			})
-		}
-	} else {
+	if !isRelevant {
 		// Remove from tx repository
-		if _, err := node.txs.Remove(ctx, hash, -1); err != nil {
+		if _, err := node.txs.Remove(ctx, *hash, -1); err != nil {
 			return errors.Wrap(err, "Failed to remove from tx repo")
 		}
+		return nil
+	}
+
+	// Notify of conflicting txs
+	if len(conflicts) > 0 {
+		node.txs.MarkUnsafe(ctx, *hash)
+		node.txStateChannel.Add(handlers.TxState{
+			handlers.ListenerMsgTxStateUnsafe,
+			*hash,
+		})
+	} else if (added && tx.Safe) || newlySafe {
+		// Note: A tx can be marked safe without being marked trusted if it is created internally.
+		node.txStateChannel.Add(handlers.TxState{
+			handlers.ListenerMsgTxStateSafe,
+			*hash,
+		})
 	}
 
 	return nil
@@ -902,7 +913,7 @@ func (node *Node) checkTxDelays(ctx context.Context) {
 
 		// Get newly safe txs
 		cutoffTime := time.Now().Add(time.Millisecond * -time.Duration(node.config.SafeTxDelay))
-		txids, err := node.txs.GetNewSafe(ctx, cutoffTime)
+		txids, err := node.txs.GetNewSafe(ctx, node.memPool, cutoffTime)
 		if err != nil {
 			logger.Warn(ctx, err.Error())
 			node.restart(ctx)
@@ -910,6 +921,7 @@ func (node *Node) checkTxDelays(ctx context.Context) {
 		}
 
 		for _, txid := range txids {
+			logger.Debug(ctx, "Tx is now safe : %s", txid.String())
 			node.txStateChannel.Add(handlers.TxState{
 				handlers.ListenerMsgTxStateSafe,
 				txid,

--- a/pkg/spynode/untrusted_node.go
+++ b/pkg/spynode/untrusted_node.go
@@ -188,7 +188,7 @@ func (node *UntrustedNode) BroadcastTxs(ctx context.Context, txs []*wire.MsgTx) 
 // ProcessBlock is called when a block is being processed.
 // It is responsible for any cleanup as a result of a block.
 func (node *UntrustedNode) ProcessBlock(ctx context.Context, txids []*bitcoin.Hash32) error {
-	node.txTracker.Remove(ctx, txids)
+	node.txTracker.RemoveList(ctx, txids)
 	return nil
 }
 


### PR DESCRIPTION
This was a rough one and needs some explanation.

### Background

There is a trusted node that we know is giving us reliable data. There are many untrusted nodes that give us more views into the network since our trusted node would never propagate something it saw as a double spend.

There are two places spynode holds tx data. Tx Repo and the Mempool. Tx Repo is only for relevant txs. Mempool is for all unconfirmed txs to monitor for double spends.

To consider a tx as valid, spynode has to either get the tx from the trusted node or get an inventory message containing the txid from the trusted node and hold onto the transaction for `SafeTxDelay` ms without seeing a double spend attempt. Untrusted nodes will also be sending tx inventories and if they contain new txids, then spynode requests the txs from them. So the inventory txids and tx can each come from either trusted or untrusted nodes and we may receive the tx before or after the trusted node gives us the txid in an inventory message.

### Problem

The problem is that we don't want to put non-relevant txs in the tx repo, but we don't know if they are relevant until we receive the full tx. It was possible that we received the tx inventory from the trusted node while we were already waiting to receive the tx from another node. This would attempt to mark the tx as trusted in the tx repo, but it doesn't exist yet, so it doesn't get marked. Then we receive the tx and determine it is relevant, but don't receive another tx inventory from the trusted node and it never gets marked as trusted, so it is not processed until it is confirmed.

### Solution

To fix this I had to add an additional trusted flag to the mempool. We still want the trusted flag in the tx repo so it doesn't always have to do a lookup in the mempool to mark a tx as safe, but we need it in mempool for the scenario described above so we can remember that the trusted node has verified it even if it happens before we have the tx in tx repo. This then also requires that if a tx in the repo is past the safe delay, but not marked as trusted in the tx repo, we need to check the mempool to know if it has been marked as trusted there.

### Extra

I also moved all of the `HandleTxState` calls into one thread being fed by a channel so that they all happen on the same thread in the client application. This prevents threading issues with simpler clients as well as prevents the callback from holding up other spynode threads.