### PR TITLE
Update ballots to lock in valid positions/quantities

### DIFF
--- a/cmd/smartcontractd/tests/asset_test.go
+++ b/cmd/smartcontractd/tests/asset_test.go
@@ -729,14 +729,15 @@ func mockUpAsset(ctx context.Context, transfers, enforcement, voting bool, quant
 	index uint64, payload assets.Asset, permitted, issuer, holder bool) error {
 
 	var assetData = state.Asset{
-		Code:                       protocol.AssetCodeFromContract(test.ContractKey.Address, index),
-		AssetType:                  payload.Code(),
-		TransfersPermitted:         transfers,
-		EnforcementOrdersPermitted: enforcement,
-		VotingRights:               voting,
-		TokenQty:                   quantity,
-		CreatedAt:                  protocol.CurrentTimestamp(),
-		UpdatedAt:                  protocol.CurrentTimestamp(),
+		Code:                        protocol.AssetCodeFromContract(test.ContractKey.Address, index),
+		AssetType:                   payload.Code(),
+		TransfersPermitted:          transfers,
+		EnforcementOrdersPermitted:  enforcement,
+		VotingRights:                voting,
+		TokenQty:                    quantity,
+		AssetModificationGovernance: 1,
+		CreatedAt:                   protocol.CurrentTimestamp(),
+		UpdatedAt:                   protocol.CurrentTimestamp(),
 	}
 
 	testAssetType = payload.Code()

--- a/cmd/smartcontractd/tests/tests_test.go
+++ b/cmd/smartcontractd/tests/tests_test.go
@@ -14,9 +14,11 @@ import (
 	"github.com/tokenized/smart-contract/internal/holdings"
 	"github.com/tokenized/smart-contract/internal/platform/protomux"
 	"github.com/tokenized/smart-contract/internal/platform/tests"
+	"github.com/tokenized/smart-contract/internal/vote"
 	"github.com/tokenized/smart-contract/pkg/inspector"
 	"github.com/tokenized/smart-contract/pkg/wallet"
 	"github.com/tokenized/smart-contract/pkg/wire"
+
 	"github.com/tokenized/specification/dist/golang/actions"
 	"github.com/tokenized/specification/dist/golang/protocol"
 )
@@ -251,6 +253,7 @@ func resetTest(ctx context.Context) error {
 	asset.Reset(ctx)
 	contract.Reset(ctx)
 	holdings.Reset(ctx)
+	vote.Reset(ctx)
 	a.SetResponder(respondTx)
 	a.SetReprocessor(reprocessTx)
 	return test.Reset(ctx)

--- a/internal/platform/state/models.go
+++ b/internal/platform/state/models.go
@@ -121,7 +121,8 @@ type Vote struct {
 	AppliedTxId *protocol.TxId     `json:"AppliedTxId,omitempty"`
 	CompletedAt protocol.Timestamp `json:"CompletedAt,omitempty"`
 
-	Ballots []*Ballot `json:"Ballots,omitempty"`
+	Ballots    map[bitcoin.Hash20]Ballot `json:"-"` // json can only encode string maps
+	BallotList []Ballot                  `json:"Ballots,omitempty"`
 }
 
 type Ballot struct {

--- a/internal/vote/models.go
+++ b/internal/vote/models.go
@@ -2,6 +2,8 @@ package vote
 
 import (
 	"github.com/tokenized/smart-contract/internal/platform/state"
+	"github.com/tokenized/smart-contract/pkg/bitcoin"
+
 	"github.com/tokenized/specification/dist/golang/actions"
 	"github.com/tokenized/specification/dist/golang/protocol"
 )
@@ -20,10 +22,11 @@ type NewVote struct {
 	TokenQty     uint64             `json:"TokenQty,omitempty"`
 	Expires      protocol.Timestamp `json:"Expires,omitempty"`
 	Timestamp    protocol.Timestamp `json:"Timestamp,omitempty"`
+
+	Ballots map[bitcoin.Hash20]state.Ballot `json:"-"`
 }
 
-// UpdateVote struct { defines what information may be provided to modify an
-// existing Vote.
+// UpdateVote defines what information may be provided to modify an existing Vote.
 type UpdateVote struct {
 	CompletedAt *protocol.Timestamp `json:"CompletedAt,omitempty"`
 	AppliedTxId *protocol.TxId      `json:"AppliedTxId,omitempty"`


### PR DESCRIPTION
Now when a vote is officially started, all holdings that are allowed to vote are pulled into ballots and when a ballot action is received it just applies the vote to it. This prevents issues with holdings being transferred during a vote.