### PR TITLE
Check master address and minimum tx fee.

### DIFF
--- a/cmd/smartcontractd/bootstrap/bootstrap.go
+++ b/cmd/smartcontractd/bootstrap/bootstrap.go
@@ -87,6 +87,7 @@ func NewNodeConfig(ctx context.Context, cfg *config.Config) *node.Config {
 		ContractProviderID: cfg.Contract.OperatorName,
 		Version:            cfg.Contract.Version,
 		FeeRate:            cfg.Contract.FeeRate,
+		MinFeeRate:         cfg.Contract.MinFeeRate,
 		DustLimit:          cfg.Contract.DustLimit,
 		RequestTimeout:     cfg.Contract.RequestTimeout,
 		PreprocessThreads:  cfg.Contract.PreprocessThreads,

--- a/cmd/smartcontractd/tests/asset_test.go
+++ b/cmd/smartcontractd/tests/asset_test.go
@@ -91,7 +91,7 @@ func createAsset(t *testing.T) {
 	}
 
 	// Build asset definition transaction
-	assetTx := wire.NewMsgTx(2)
+	assetTx := wire.NewMsgTx(1)
 
 	assetInputHash := fundingTx.TxHash()
 
@@ -217,7 +217,7 @@ func adminMemberAsset(t *testing.T) {
 	}
 
 	// Build asset definition transaction
-	assetTx := wire.NewMsgTx(2)
+	assetTx := wire.NewMsgTx(1)
 
 	assetInputHash := fundingTx.TxHash()
 
@@ -287,7 +287,7 @@ func adminMemberAsset(t *testing.T) {
 	assetPayloadData.MembershipClass = "Owner"
 
 	// Build asset definition transaction
-	asset2Tx := wire.NewMsgTx(2)
+	asset2Tx := wire.NewMsgTx(1)
 
 	asset2InputHash := fundingTx.TxHash()
 
@@ -386,7 +386,7 @@ func assetIndex(t *testing.T) {
 	}
 
 	// Build asset definition transaction
-	assetTx := wire.NewMsgTx(2)
+	assetTx := wire.NewMsgTx(1)
 
 	assetInputHash := fundingTx.TxHash()
 
@@ -444,7 +444,7 @@ func assetIndex(t *testing.T) {
 	testAssetCodes = append(testAssetCodes, *protocol.AssetCodeFromContract(test.ContractKey.Address, 1))
 
 	// Build asset definition transaction
-	assetTx = wire.NewMsgTx(2)
+	assetTx = wire.NewMsgTx(1)
 
 	assetInputHash = fundingTx.TxHash()
 
@@ -536,7 +536,7 @@ func assetAmendment(t *testing.T) {
 	})
 
 	// Build amendment transaction
-	amendmentTx := wire.NewMsgTx(2)
+	amendmentTx := wire.NewMsgTx(1)
 
 	amendmentInputHash := fundingTx.TxHash()
 
@@ -646,7 +646,7 @@ func assetProposalAmendment(t *testing.T) {
 	amendmentData.Amendments = append(amendmentData.Amendments, &assetAmendment)
 
 	// Build amendment transaction
-	amendmentTx := wire.NewMsgTx(2)
+	amendmentTx := wire.NewMsgTx(1)
 
 	amendmentInputHash := fundingTx.TxHash()
 

--- a/cmd/smartcontractd/tests/contract_test.go
+++ b/cmd/smartcontractd/tests/contract_test.go
@@ -79,7 +79,7 @@ func createContract(t *testing.T) {
 	fundingTx := tests.MockFundingTx(ctx, test.RPCNode, 100004, issuerKey.Address)
 
 	// Build offer transaction
-	offerTx := wire.NewMsgTx(2)
+	offerTx := wire.NewMsgTx(1)
 
 	offerInputHash := fundingTx.TxHash()
 
@@ -300,7 +300,7 @@ func oracleContract(t *testing.T) {
 	fundingTx := tests.MockFundingTx(ctx, test.RPCNode, 100004, issuerKey.Address)
 
 	// Build offer transaction
-	offerTx := wire.NewMsgTx(2)
+	offerTx := wire.NewMsgTx(1)
 
 	offerInputHash := fundingTx.TxHash()
 
@@ -310,7 +310,7 @@ func oracleContract(t *testing.T) {
 
 	// To contract
 	script, _ := test.ContractKey.Address.LockingScript()
-	offerTx.TxOut = append(offerTx.TxOut, wire.NewTxOut(750000, script))
+	offerTx.TxOut = append(offerTx.TxOut, wire.NewTxOut(75000, script))
 
 	// Data output
 	script, err = protocol.Serialize(&offerData, test.NodeConfig.IsTest)
@@ -489,7 +489,7 @@ func contractAmendment(t *testing.T) {
 	})
 
 	// Build amendment transaction
-	amendmentTx := wire.NewMsgTx(2)
+	amendmentTx := wire.NewMsgTx(1)
 
 	amendmentInputHash := fundingTx.TxHash()
 
@@ -591,7 +591,7 @@ func contractListAmendment(t *testing.T) {
 	})
 
 	// Build amendment transaction
-	amendmentTx := wire.NewMsgTx(2)
+	amendmentTx := wire.NewMsgTx(1)
 
 	amendmentInputHash := fundingTx.TxHash()
 
@@ -667,7 +667,7 @@ func contractListAmendment(t *testing.T) {
 	}
 
 	// Build amendment transaction
-	amendmentTx = wire.NewMsgTx(2)
+	amendmentTx = wire.NewMsgTx(1)
 
 	amendmentInputHash = fundingTx.TxHash()
 
@@ -772,7 +772,7 @@ func contractOracleAmendment(t *testing.T) {
 	})
 
 	// Build amendment transaction
-	amendmentTx := wire.NewMsgTx(2)
+	amendmentTx := wire.NewMsgTx(1)
 
 	// From issuer
 	fundingTx := tests.MockFundingTx(ctx, test.RPCNode, 100015, issuerKey.Address)
@@ -866,7 +866,7 @@ func contractProposalAmendment(t *testing.T) {
 	amendmentData.Amendments = append(amendmentData.Amendments, &assetAmendment)
 
 	// Build amendment transaction
-	amendmentTx := wire.NewMsgTx(2)
+	amendmentTx := wire.NewMsgTx(1)
 
 	amendmentInputHash := fundingTx.TxHash()
 

--- a/cmd/smartcontractd/tests/enforcement_test.go
+++ b/cmd/smartcontractd/tests/enforcement_test.go
@@ -61,7 +61,7 @@ func freezeOrder(t *testing.T) {
 	})
 
 	// Build order transaction
-	orderTx := wire.NewMsgTx(2)
+	orderTx := wire.NewMsgTx(1)
 
 	orderInputHash := fundingTx.TxHash()
 
@@ -162,7 +162,7 @@ func freezeAuthorityOrder(t *testing.T) {
 	orderData.OrderSignature = sig.Bytes()
 
 	// Build order transaction
-	orderTx := wire.NewMsgTx(2)
+	orderTx := wire.NewMsgTx(1)
 
 	orderInputHash := fundingTx.TxHash()
 
@@ -253,7 +253,7 @@ func thawOrder(t *testing.T) {
 	}
 
 	// Build order transaction
-	orderTx := wire.NewMsgTx(2)
+	orderTx := wire.NewMsgTx(1)
 
 	orderInputHash := fundingTx.TxHash()
 
@@ -339,7 +339,7 @@ func confiscateOrder(t *testing.T) {
 		&actions.TargetAddressField{Address: userKey.Address.Bytes(), Quantity: 50})
 
 	// Build order transaction
-	orderTx := wire.NewMsgTx(2)
+	orderTx := wire.NewMsgTx(1)
 
 	orderInputHash := fundingTx.TxHash()
 
@@ -445,7 +445,7 @@ func reconcileOrder(t *testing.T) {
 		&actions.QuantityIndexField{Index: 0, Quantity: 75000})
 
 	// Build order transaction
-	orderTx := wire.NewMsgTx(2)
+	orderTx := wire.NewMsgTx(1)
 
 	orderInputHash := fundingTx.TxHash()
 
@@ -548,7 +548,7 @@ func mockUpFreeze(ctx context.Context, t *testing.T, address bitcoin.RawAddress,
 	})
 
 	// Build order transaction
-	orderTx := wire.NewMsgTx(2)
+	orderTx := wire.NewMsgTx(1)
 
 	orderInputHash := fundingTx.TxHash()
 

--- a/cmd/smartcontractd/tests/governance_test.go
+++ b/cmd/smartcontractd/tests/governance_test.go
@@ -75,7 +75,7 @@ func holderProposal(t *testing.T) {
 	})
 
 	// Build proposal transaction
-	proposalTx := wire.NewMsgTx(2)
+	proposalTx := wire.NewMsgTx(1)
 
 	proposalInputHash := fundingTx.TxHash()
 
@@ -182,7 +182,7 @@ func sendBallot(t *testing.T) {
 	t.Logf("Vote Tx : %s", testVoteTxId.String())
 
 	// Build transaction
-	ballotTx := wire.NewMsgTx(2)
+	ballotTx := wire.NewMsgTx(1)
 
 	ballotInputHash := fundingTx.TxHash()
 
@@ -283,7 +283,7 @@ func adminBallot(t *testing.T) {
 	}
 
 	// Build transaction
-	ballotTx := wire.NewMsgTx(2)
+	ballotTx := wire.NewMsgTx(1)
 
 	ballotInputHash := fundingTx.TxHash()
 
@@ -347,7 +347,7 @@ func adminBallot(t *testing.T) {
 	fundingTx = tests.MockFundingTx(ctx, test.RPCNode, 100010, user2Key.Address)
 
 	// Build transaction
-	ballotTx = wire.NewMsgTx(2)
+	ballotTx = wire.NewMsgTx(1)
 
 	ballotInputHash = fundingTx.TxHash()
 
@@ -632,7 +632,7 @@ func mockUpVote(ctx context.Context, voteSystem uint32) error {
 	}
 
 	// Build proposal transaction
-	proposalTx := wire.NewMsgTx(2)
+	proposalTx := wire.NewMsgTx(1)
 
 	proposalInputHash := fundingTx.TxHash()
 
@@ -675,7 +675,7 @@ func mockUpVote(ctx context.Context, voteSystem uint32) error {
 	}
 
 	// Build proposal transaction
-	voteTx := wire.NewMsgTx(2)
+	voteTx := wire.NewMsgTx(1)
 
 	voteInputHash := proposalTx.TxHash()
 
@@ -745,7 +745,7 @@ func mockUpProposalType(ctx context.Context, proposalType uint32, assetCode *pro
 	})
 
 	// Build proposal transaction
-	proposalTx := wire.NewMsgTx(2)
+	proposalTx := wire.NewMsgTx(1)
 
 	proposalInputHash := fundingTx.TxHash()
 
@@ -906,7 +906,7 @@ func mockUpVoteResultTx(ctx context.Context, result string) error {
 	fundingTx := tests.MockFundingTx(ctx, test.RPCNode, 100011, issuerKey.Address)
 
 	// Build result transaction
-	resultTx := wire.NewMsgTx(2)
+	resultTx := wire.NewMsgTx(1)
 
 	resultInputHash := fundingTx.TxHash()
 

--- a/cmd/smartcontractd/tests/transfer_test.go
+++ b/cmd/smartcontractd/tests/transfer_test.go
@@ -98,7 +98,7 @@ func simpleTransfersBenchmark(b *testing.B) {
 		transferData.Assets = append(transferData.Assets, &assetTransferData)
 
 		// Build transfer transaction
-		transferTx := wire.NewMsgTx(2)
+		transferTx := wire.NewMsgTx(1)
 
 		transferInputHash := fundingTx.TxHash()
 
@@ -279,7 +279,7 @@ func separateTransfersBenchmark(b *testing.B) {
 		transferData.Assets = append(transferData.Assets, &assetTransferData)
 
 		// Build transfer transaction
-		transferTx := wire.NewMsgTx(2)
+		transferTx := wire.NewMsgTx(1)
 
 		// From sender
 		fundingTx := tests.MockFundingTx(ctx, test.RPCNode, 100000+uint64(i), senderKey.Address)
@@ -480,7 +480,7 @@ func oracleTransfersBenchmark(b *testing.B) {
 		transferData.Assets = append(transferData.Assets, &assetTransferData)
 
 		// Build transfer transaction
-		transferTx := wire.NewMsgTx(2)
+		transferTx := wire.NewMsgTx(1)
 
 		transferInputHash := fundingTx.TxHash()
 
@@ -656,7 +656,7 @@ func splitTransfer(b *testing.B, ctx context.Context, sender *wallet.Key, balanc
 	transferData.Assets = append(transferData.Assets, &assetTransferData)
 
 	// Build transfer transaction
-	transferTx := wire.NewMsgTx(2)
+	transferTx := wire.NewMsgTx(1)
 
 	transferInputHash := fundingTx.TxHash()
 
@@ -894,7 +894,7 @@ func sendTokens(t *testing.T) {
 	transferData.Assets = append(transferData.Assets, &assetTransferData)
 
 	// Build transfer transaction
-	transferTx := wire.NewMsgTx(2)
+	transferTx := wire.NewMsgTx(1)
 
 	transferInputHash := fundingTx.TxHash()
 
@@ -1081,7 +1081,7 @@ func sendTokens(t *testing.T) {
 	fundingTx2 := tests.MockFundingTx(ctx, test.RPCNode, 100022, issuerKey.Address)
 
 	// Build transfer transaction
-	transferTx2 := wire.NewMsgTx(2)
+	transferTx2 := wire.NewMsgTx(1)
 
 	transferInputHash = fundingTx2.TxHash()
 
@@ -1253,7 +1253,7 @@ func multiExchange(t *testing.T) {
 	transferData.Assets = append(transferData.Assets, &assetTransfer2Data)
 
 	// Build transfer transaction
-	transferTx := wire.NewMsgTx(2)
+	transferTx := wire.NewMsgTx(1)
 
 	// From user1
 	transferInputHash := funding1Tx.TxHash()
@@ -1492,7 +1492,7 @@ func bitcoinExchange(t *testing.T) {
 	transferData.Assets = append(transferData.Assets, &assetTransfer2Data)
 
 	// Build transfer transaction
-	transferTx := wire.NewMsgTx(2)
+	transferTx := wire.NewMsgTx(1)
 
 	// From user1
 	transferInputHash := funding1Tx.TxHash()
@@ -1674,7 +1674,7 @@ func multiExchangeLock(t *testing.T) {
 	transferData.Assets = append(transferData.Assets, &assetTransfer2Data)
 
 	// Build transfer transaction
-	transferTx := wire.NewMsgTx(2)
+	transferTx := wire.NewMsgTx(1)
 
 	// From user1
 	transferInputHash := funding1Tx.TxHash()
@@ -1777,7 +1777,7 @@ func multiExchangeLock(t *testing.T) {
 	transferOtherData.Assets = append(transferOtherData.Assets, &assetTransferOtherData)
 
 	// Build transfer transaction
-	transferOtherTx := wire.NewMsgTx(2)
+	transferOtherTx := wire.NewMsgTx(1)
 
 	// From user
 	transferOtherTx.TxIn = append(transferOtherTx.TxIn,
@@ -1855,7 +1855,7 @@ func multiExchangeLock(t *testing.T) {
 	}
 
 	// Build transfer transaction
-	rejectOtherTx := wire.NewMsgTx(2)
+	rejectOtherTx := wire.NewMsgTx(1)
 
 	// From other contract (second output of multi-contract transfer request)
 	rejectOtherTx.TxIn = append(rejectOtherTx.TxIn,
@@ -2070,7 +2070,7 @@ func multiExchangeTimeout(t *testing.T) {
 	transferData.Assets = append(transferData.Assets, &assetTransfer2Data)
 
 	// Build transfer transaction
-	transferTx := wire.NewMsgTx(2)
+	transferTx := wire.NewMsgTx(1)
 
 	// From user1
 	transferInputHash := funding1Tx.TxHash()
@@ -2175,7 +2175,7 @@ func multiExchangeTimeout(t *testing.T) {
 	transferOtherData.Assets = append(transferOtherData.Assets, &assetTransferOtherData)
 
 	// Build transfer transaction
-	transferOtherTx := wire.NewMsgTx(2)
+	transferOtherTx := wire.NewMsgTx(1)
 
 	// From user
 	transferOtherTx.TxIn = append(transferOtherTx.TxIn,
@@ -2412,7 +2412,7 @@ func oracleTransfer(t *testing.T) {
 	transferData.Assets = append(transferData.Assets, &assetTransferData)
 
 	// Build transfer transaction
-	transferTx := wire.NewMsgTx(2)
+	transferTx := wire.NewMsgTx(1)
 
 	transferInputHash := fundingTx.TxHash()
 
@@ -2605,7 +2605,7 @@ func oracleTransferBad(t *testing.T) {
 	transferData.Assets = append(transferData.Assets, &bitcoinTransferData)
 
 	// Build transfer transaction
-	transferTx := wire.NewMsgTx(2)
+	transferTx := wire.NewMsgTx(1)
 
 	// From issuer
 	transferInputHash := fundingTx.TxHash()
@@ -2762,7 +2762,7 @@ func permitted(t *testing.T) {
 	transferData.Assets = append(transferData.Assets, &assetTransferData)
 
 	// Build transfer transaction
-	transferTx := wire.NewMsgTx(2)
+	transferTx := wire.NewMsgTx(1)
 
 	transferInputHash := fundingTx.TxHash()
 
@@ -2875,7 +2875,7 @@ func permittedBad(t *testing.T) {
 	transferData.Assets = append(transferData.Assets, &assetTransferData)
 
 	// Build transfer transaction
-	transferTx := wire.NewMsgTx(2)
+	transferTx := wire.NewMsgTx(1)
 
 	// From issuer
 	transferInputHash := fundingTx.TxHash()

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 		RequestTimeout    uint64  `default:"60000000000" envconfig:"REQUEST_TIMEOUT"` // Default 1 minute
 		PreprocessThreads int     `default:"4" envconfig:"PREPROCESS_THREADS"`
 		IsTest            bool    `default:"true" envconfig:"IS_TEST"`
+		MinFeeRate        float32 `default:"0.5" envconfig:"MIN_FEE_RATE"`
 	}
 	Bitcoin struct {
 		Network string `default:"mainnet" envconfig:"BITCOIN_CHAIN"`

--- a/internal/platform/node/node.go
+++ b/internal/platform/node/node.go
@@ -55,6 +55,7 @@ type Config struct {
 	DustLimit          uint64
 	Net                bitcoin.Network
 	FeeRate            float32
+	MinFeeRate         float32
 	RequestTimeout     uint64 // Nanoseconds until a request to another contract times out and the original request is rejected.
 	PreprocessThreads  int
 	IsTest             bool

--- a/internal/platform/tests/main.go
+++ b/internal/platform/tests/main.go
@@ -77,6 +77,7 @@ func New(logFileName string) *Test {
 		DustLimit:          256,
 		Net:                bitcoin.MainNet,
 		FeeRate:            1.0,
+		MinFeeRate:         0.5,
 		RequestTimeout:     1000000000000,
 		IsTest:             true,
 	}

--- a/pkg/inspector/inspector.go
+++ b/pkg/inspector/inspector.go
@@ -38,6 +38,10 @@ var (
 	// ErrMissingOutputs
 	ErrMissingOutputs = errors.New("Message is missing outputs")
 
+	ErrNegativeFee  = errors.New("Negative fee")
+	ErrUnpromotedTx = errors.New("Unpromoted tx")
+	ErrIncompleteTx = errors.New("Incomplete tx")
+
 	// prefixP2PKH Pay to PKH prefix
 	prefixP2PKH = []byte{0x76, 0xA9}
 )


### PR DESCRIPTION
NEX-150 Add a check before accepting a contract offer that the master address field is a known format for an address. This caused a failure at least once when the field was populated with a base58 address (not binary) and passed the original contract offer check, but caused the smart contract to fail when it tried to read that field in the production of the contract formation response.

NEX-29 Add a minimum tx fee requirement configuration value to help prevent any sort of low fee double spend attack. It can be set to zero to turn it off.

Also changed a lot of the versions in txs in test to 1 instead of 2 because I don't think version 2 transactions will ever really be a thing in BSV.