### PR TITLE
Spynode Update and S3 Storage fix.

### DIFF
--- a/cmd/smartcontractd/listeners/node.go
+++ b/cmd/smartcontractd/listeners/node.go
@@ -77,7 +77,7 @@ func NewServer(
 	txFilter *filters.TxFilter,
 	holdingsChannel *holdings.CacheChannel,
 ) *Server {
-	result := Server{
+	result := &Server{
 		wallet:           wallet,
 		Config:           config,
 		MasterDB:         masterDB,
@@ -97,10 +97,10 @@ func NewServer(
 		holdingsChannel:  holdingsChannel,
 	}
 
-	return &result
+	return result
 }
 
-func (server *Server) Run(ctx context.Context) error {
+func (server *Server) Load(ctx context.Context) error {
 	// Set responder
 	server.Handler.SetResponder(server.respondTx)
 	server.Handler.SetReprocessor(server.reprocessTx)
@@ -115,8 +115,13 @@ func (server *Server) Run(ctx context.Context) error {
 	}
 
 	if err := server.Tracer.Load(ctx, server.MasterDB); err != nil {
-		return err
+		return errors.Wrap(err, "load trader")
 	}
+
+	return nil
+}
+
+func (server *Server) Run(ctx context.Context) error {
 
 	wg := sync.WaitGroup{}
 

--- a/cmd/smartcontractd/main.go
+++ b/cmd/smartcontractd/main.go
@@ -167,6 +167,10 @@ func main() {
 		logger.Fatal(ctx, "Load Wallet : %s", err)
 	}
 
+	if err := node.Load(ctx); err != nil {
+		logger.Fatal(ctx, "Load Server : %s", err)
+	}
+
 	// -------------------------------------------------------------------------
 	// Start Node Service
 

--- a/cmd/smartcontractd/tests/contract_test.go
+++ b/cmd/smartcontractd/tests/contract_test.go
@@ -330,6 +330,10 @@ func oracleContract(t *testing.T) {
 		test.RPCNode, nil, test.Headers, test.Scheduler, tracer, test.UTXOs, txFilter,
 		holdingsChannel)
 
+	if err := server.Load(ctx); err != nil {
+		t.Fatalf("Failed to load server : %s", err)
+	}
+
 	if err := server.SyncWallet(ctx); err != nil {
 		t.Fatalf("Failed to load wallet : %s", err)
 	}

--- a/cmd/smartcontractd/tests/transfer_test.go
+++ b/cmd/smartcontractd/tests/transfer_test.go
@@ -132,6 +132,10 @@ func simpleTransfersBenchmark(b *testing.B) {
 		test.RPCNode, nil, test.Headers, test.Scheduler, tracer, test.UTXOs, txFilter,
 		test.HoldingsChannel)
 
+	if err := server.Load(ctx); err != nil {
+		b.Fatalf("Failed to load server : %s", err)
+	}
+
 	if err := server.SyncWallet(ctx); err != nil {
 		b.Fatalf("Failed to load wallet : %s", err)
 	}
@@ -312,6 +316,10 @@ func separateTransfersBenchmark(b *testing.B) {
 	server := listeners.NewServer(test.Wallet, a, &test.NodeConfig, test.MasterDB,
 		test.RPCNode, nil, test.Headers, test.Scheduler, tracer, test.UTXOs, txFilter,
 		test.HoldingsChannel)
+
+	if err := server.Load(ctx); err != nil {
+		b.Fatalf("Failed to load server : %s", err)
+	}
 
 	if err := server.SyncWallet(ctx); err != nil {
 		b.Fatalf("Failed to load wallet : %s", err)
@@ -513,6 +521,10 @@ func oracleTransfersBenchmark(b *testing.B) {
 	server := listeners.NewServer(test.Wallet, a, &test.NodeConfig, test.MasterDB,
 		test.RPCNode, nil, test.Headers, test.Scheduler, tracer, test.UTXOs, txFilter,
 		test.HoldingsChannel)
+
+	if err := server.Load(ctx); err != nil {
+		b.Fatalf("Failed to load server : %s", err)
+	}
 
 	if err := server.SyncWallet(ctx); err != nil {
 		b.Fatalf("Failed to load wallet : %s", err)
@@ -752,6 +764,10 @@ func treeTransfersBenchmark(b *testing.B) {
 	server := listeners.NewServer(test.Wallet, a, &test.NodeConfig, test.MasterDB,
 		test.RPCNode, nil, test.Headers, test.Scheduler, tracer, test.UTXOs, txFilter,
 		test.HoldingsChannel)
+
+	if err := server.Load(ctx); err != nil {
+		b.Fatalf("Failed to load server : %s", err)
+	}
 
 	if err := server.SyncWallet(ctx); err != nil {
 		b.Fatalf("Failed to load wallet : %s", err)
@@ -2441,6 +2457,10 @@ func oracleTransfer(t *testing.T) {
 		test.RPCNode, nil, test.Headers, test.Scheduler, tracer, test.UTXOs, txFilter,
 		holdingsChannel)
 
+	if err := server.Load(ctx); err != nil {
+		t.Fatalf("Failed to load server : %s", err)
+	}
+
 	if err := server.SyncWallet(ctx); err != nil {
 		t.Fatalf("Failed to load wallet : %s", err)
 	}
@@ -2640,6 +2660,10 @@ func oracleTransferBad(t *testing.T) {
 	server := listeners.NewServer(test.Wallet, a, &test.NodeConfig, test.MasterDB,
 		test.RPCNode, nil, test.Headers, test.Scheduler, tracer, test.UTXOs, txFilter,
 		holdingsChannel)
+
+	if err := server.Load(ctx); err != nil {
+		t.Fatalf("Failed to load server : %s", err)
+	}
 
 	if err := server.SyncWallet(ctx); err != nil {
 		t.Fatalf("Failed to load wallet : %s", err)

--- a/pkg/spynode/blocks.go
+++ b/pkg/spynode/blocks.go
@@ -1,0 +1,221 @@
+package spynode
+
+import (
+	"context"
+	"time"
+
+	"github.com/tokenized/smart-contract/pkg/bitcoin"
+	"github.com/tokenized/smart-contract/pkg/logger"
+	"github.com/tokenized/smart-contract/pkg/spynode/handlers"
+	"github.com/tokenized/smart-contract/pkg/wire"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrBlockNotNextBlock = errors.New("Not next block")
+	ErrBlockNotAdded     = errors.New("Block not added")
+)
+
+func (node *Node) processBlocks(ctx context.Context) error {
+
+	for !node.isStopping() {
+		// Blocks are fed into the state when received by the block handler, then pulled out and
+		//   processed here.
+		block := node.state.NextBlock()
+		if block == nil {
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+
+		if err := node.ProcessBlock(ctx, block); err != nil {
+			c := errors.Cause(err)
+			if c != ErrBlockNotNextBlock && c != ErrBlockNotAdded {
+				return err
+			}
+		}
+
+		// Request more blocks if necessary
+		// TODO Send some requests to other nodes --ce
+		getBlocks := wire.NewMsgGetData() // Block request message
+
+		for {
+			requestHash, _ := node.state.GetNextBlockToRequest()
+			if requestHash == nil {
+				break
+			}
+
+			logger.Debug(ctx, "Requesting block : %s", requestHash.String())
+			getBlocks.AddInvVect(wire.NewInvVect(wire.InvTypeBlock, requestHash))
+			if len(getBlocks.InvList) == wire.MaxInvPerMsg {
+				// Start new get data (block request) message
+				if !node.queueOutgoing(getBlocks) {
+					return nil
+				}
+				getBlocks = wire.NewMsgGetData()
+			}
+		}
+
+		// Add any non-full requests.
+		if len(getBlocks.InvList) > 0 {
+			if !node.queueOutgoing(getBlocks) {
+				return nil
+			}
+		}
+	}
+
+	return nil
+}
+
+func (node *Node) ProcessBlock(ctx context.Context, block *wire.MsgBlock) error {
+	node.blockLock.Lock()
+	defer node.blockLock.Unlock()
+
+	hash := block.Header.BlockHash()
+
+	if node.blocks.Contains(hash) {
+		height, _ := node.blocks.Height(hash)
+		logger.Warn(ctx, "Already have block (%d) : %s", height, hash.String())
+		return ErrBlockNotAdded
+	}
+
+	if block.Header.PrevBlock != *node.blocks.LastHash() {
+		// Ignore this as it can happen when there is a reorg.
+		logger.Warn(ctx, "Not next block : %s", hash.String())
+		logger.Warn(ctx, "Previous hash : %s", block.Header.PrevBlock.String())
+		return ErrBlockNotNextBlock // Unknown or out of order block
+	}
+
+	// Validate
+	valid, err := validateMerkleHash(ctx, block)
+	if err != nil {
+		return errors.Wrap(err, "Failed to validate merkle hash")
+	}
+	if !valid {
+		logger.Warn(ctx, "Invalid merkle hash for block %s", hash.String())
+		return ErrBlockNotAdded
+	}
+
+	// Add to repo
+	if err = node.blocks.Add(ctx, &block.Header); err != nil {
+		return err
+	}
+
+	// If we are in sync we can save after every block
+	if node.state.IsReady() {
+		if err := node.blocks.Save(ctx); err != nil {
+			return errors.Wrap(err, "save blocks")
+		}
+	}
+
+	// Get unconfirmed "relevant" txs
+	var unconfirmed []bitcoin.Hash32
+	// This locks the tx repo so that propagated txs don't interfere while a block is being
+	//   processed.
+	unconfirmed, err = node.txs.GetUnconfirmed(ctx)
+	if err != nil {
+		return errors.Wrap(err, "get unconfirmed txs")
+	}
+
+	// Send block notification
+	height := node.blocks.LastHeight()
+	blockMessage := handlers.BlockMessage{Hash: *hash, Height: height, Time: block.Header.Timestamp}
+	for _, listener := range node.listeners {
+		listener.HandleBlock(ctx, handlers.ListenerMsgBlock, &blockMessage)
+	}
+
+	// Notify Tx for block and tx listeners
+	hashes, err := block.TxHashes()
+	if err != nil {
+		node.txs.ReleaseUnconfirmed(ctx) // Release unconfirmed
+		return errors.Wrap(err, "get block txs")
+	}
+
+	logger.Debug(ctx, "Processing block %d (%d tx) : %s", height, len(hashes), hash)
+	inUnconfirmed := false
+	for i, txHash := range hashes {
+		// Remove from unconfirmed. Only matching are in unconfirmed.
+		inUnconfirmed, unconfirmed = removeHash(*txHash, unconfirmed)
+
+		// Remove from mempool
+		inMemPool := false
+		if node.state.IsReady() {
+			inMemPool = node.memPool.RemoveTransaction(*txHash)
+		}
+
+		if inUnconfirmed {
+			// Already seen and marked relevant
+			node.txStateChannel.Add(handlers.TxState{
+				handlers.ListenerMsgTxStateConfirm,
+				*txHash,
+			})
+		} else if !inMemPool {
+			// Not seen yet
+			node.confTxChannel.Add(handlers.TxData{
+				Msg:             block.Transactions[i],
+				ConfirmedHeight: height,
+			})
+
+			// Transaction wasn't in the mempool.
+			// Check for transactions in the mempool with conflicting inputs (double spends).
+			if conflicting := node.memPool.Conflicting(block.Transactions[i]); len(conflicting) > 0 {
+				for _, confHash := range conflicting {
+					if containsHash(confHash, unconfirmed) { // Only send for txs that previously matched filters.
+						node.txStateChannel.Add(handlers.TxState{
+							handlers.ListenerMsgTxStateCancel,
+							confHash,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	// Perform any block cleanup
+	if err := node.CleanupBlock(ctx, block); err != nil {
+		logger.Debug(ctx, "Failed clean up after block : %s", hash)
+		node.txs.ReleaseUnconfirmed(ctx) // Release unconfirmed
+		return err
+	}
+
+	if !node.state.IsReady() {
+		if node.state.IsPendingSync() && node.state.BlockRequestsEmpty() {
+			node.state.SetInSync()
+			logger.Info(ctx, "Blocks in sync at height %d", node.blocks.LastHeight())
+		}
+	}
+
+	if err := node.txs.FinalizeUnconfirmed(ctx, unconfirmed); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateMerkleHash validates the merkle root hash against the transactions contained.
+// Returns true if the merkle root hash is valid.
+func validateMerkleHash(ctx context.Context, block *wire.MsgBlock) (bool, error) {
+	merkleHash, err := block.CalculateMerkleHash()
+	if err != nil {
+		return false, err
+	}
+	return *merkleHash == block.Header.MerkleRoot, nil
+}
+
+func containsHash(hash bitcoin.Hash32, list []bitcoin.Hash32) bool {
+	for _, listhash := range list {
+		if hash.Equal(&listhash) {
+			return true
+		}
+	}
+	return false
+}
+
+func removeHash(hash bitcoin.Hash32, list []bitcoin.Hash32) (bool, []bitcoin.Hash32) {
+	for i, listhash := range list {
+		if hash.Equal(&listhash) {
+			return true, append(list[:i], list[i+1:]...)
+		}
+	}
+	return false, list
+}

--- a/pkg/spynode/blocks.go
+++ b/pkg/spynode/blocks.go
@@ -199,7 +199,7 @@ func validateMerkleHash(ctx context.Context, block *wire.MsgBlock) (bool, error)
 	if err != nil {
 		return false, err
 	}
-	return *merkleHash == block.Header.MerkleRoot, nil
+	return merkleHash.Equal(&block.Header.MerkleRoot), nil
 }
 
 func containsHash(hash bitcoin.Hash32, list []bitcoin.Hash32) bool {

--- a/pkg/spynode/handlers/block.go
+++ b/pkg/spynode/handlers/block.go
@@ -2,12 +2,9 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/tokenized/smart-contract/pkg/bitcoin"
 	"github.com/tokenized/smart-contract/pkg/logger"
 	"github.com/tokenized/smart-contract/pkg/spynode/handlers/data"
-	"github.com/tokenized/smart-contract/pkg/spynode/handlers/storage"
 	"github.com/tokenized/smart-contract/pkg/wire"
 
 	"github.com/pkg/errors"
@@ -15,32 +12,14 @@ import (
 
 // BlockHandler exists to handle the block command.
 type BlockHandler struct {
-	state          *data.State
-	txChannel      *TxChannel
-	txStateChannel *TxStateChannel
-	memPool        *data.MemPool
-	blocks         *storage.BlockRepository
-	txs            *storage.TxRepository
-	listeners      []Listener
-	txFilters      []TxFilter
-	blockProcessor BlockProcessor
+	state *data.State
 }
 
 // NewBlockHandler returns a new BlockHandler with the given Config.
-func NewBlockHandler(state *data.State, txChannel *TxChannel, txStateChannel *TxStateChannel,
-	memPool *data.MemPool, blockRepo *storage.BlockRepository, txRepo *storage.TxRepository,
-	listeners []Listener, txFilters []TxFilter, blockProcessor BlockProcessor) *BlockHandler {
+func NewBlockHandler(state *data.State) *BlockHandler {
 
 	result := BlockHandler{
-		state:          state,
-		txChannel:      txChannel,
-		txStateChannel: txStateChannel,
-		memPool:        memPool,
-		blocks:         blockRepo,
-		txs:            txRepo,
-		listeners:      listeners,
-		txFilters:      txFilters,
-		blockProcessor: blockProcessor,
+		state: state,
 	}
 	return &result
 }
@@ -53,257 +32,10 @@ func (handler *BlockHandler) Handle(ctx context.Context, m wire.Message) ([]wire
 	}
 
 	receivedHash := message.BlockHash()
-	logger.Debug(ctx, "Received block : %s", receivedHash)
+	logger.Debug(ctx, "Received block : %s", receivedHash.String())
 	if !handler.state.AddBlock(receivedHash, message) {
-		logger.Warn(ctx, "Block not requested : %s", receivedHash)
-		if message.Header.PrevBlock == *handler.blocks.LastHash() {
-			if !handler.state.AddNewBlock(receivedHash, message) {
-				return nil, nil
-			}
-		} else {
-			return nil, nil
-		}
+		logger.Warn(ctx, "Block not requested : %s", receivedHash.String())
 	}
 
-	var err error
-	var valid bool
-	for {
-		block := handler.state.NextBlock()
-
-		if block == nil {
-			break // No more blocks available to process
-		}
-
-		hash := block.BlockHash()
-
-		// If we already have this block, we don't need to ask for more
-		if handler.blocks.Contains(hash) {
-			height, _ := handler.blocks.Height(hash)
-			logger.Warn(ctx, "Already have block (%d) : %s", height, hash)
-			return nil, nil
-		}
-
-		if block.Header.PrevBlock != *handler.blocks.LastHash() {
-			// Ignore this as it can happen when there is a reorg.
-			logger.Warn(ctx, "Not next block : %s", hash)
-			logger.Warn(ctx, "Previous hash : %s", block.Header.PrevBlock)
-			return nil, nil // Unknown or out of order block
-		}
-
-		// Validate
-		valid, err = validateMerkleHash(ctx, block)
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to validate merkle hash")
-		}
-		if !valid {
-			return nil, errors.New(fmt.Sprintf("Invalid merkle hash for block %s", hash))
-		}
-
-		// Add to repo
-		if err = handler.blocks.Add(ctx, &block.Header); err != nil {
-			return nil, err
-		}
-
-		// If we are in sync we can save after every block
-		if handler.state.IsReady() {
-			handler.blocks.Save(ctx)
-		}
-
-		// Get unconfirmed "relevant" txs
-		var unconfirmed []bitcoin.Hash32
-		// This locks the tx repo so that propagated txs don't interfere while a block is being
-		//   processed.
-		unconfirmed, err = handler.txs.GetUnconfirmed(ctx)
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to get unconfirmed tx hashes")
-		}
-
-		// Send block notification
-		height := handler.blocks.LastHeight()
-		blockMessage := BlockMessage{Hash: *hash, Height: height, Time: block.Header.Timestamp}
-		for _, listener := range handler.listeners {
-			listener.HandleBlock(ctx, ListenerMsgBlock, &blockMessage)
-		}
-
-		// Notify Tx for block and tx listeners
-		hashes, err := block.TxHashes()
-		if err != nil {
-			handler.txs.ReleaseUnconfirmed(ctx) // Release unconfirmed
-			return nil, errors.Wrap(err, "Failed to get block tx hashes")
-		}
-
-		logger.Debug(ctx, "Processing block %d (%d tx) : %s", height, len(hashes), hash)
-		inUnconfirmed := false
-		for i, txHash := range hashes {
-			// Remove from unconfirmed. Only matching are in unconfirmed.
-			inUnconfirmed, unconfirmed = removeHash(*txHash, unconfirmed)
-
-			// Remove from mempool
-			inMemPool := false
-			if handler.state.IsReady() {
-				inMemPool = handler.memPool.RemoveTransaction(*txHash)
-			}
-
-			if inUnconfirmed {
-				// Already seen and marked relevant
-				handler.txStateChannel.Add(TxState{
-					ListenerMsgTxStateConfirm,
-					*txHash,
-				})
-			} else if !inMemPool {
-				// Not seen yet
-				handler.txChannel.Add(TxData{
-					Msg:             block.Transactions[i],
-					ConfirmedHeight: height,
-				})
-
-				// Transaction wasn't in the mempool.
-				// Check for transactions in the mempool with conflicting inputs (double spends).
-				if conflicting := handler.memPool.Conflicting(block.Transactions[i]); len(conflicting) > 0 {
-					for _, confHash := range conflicting {
-						if containsHash(confHash, unconfirmed) { // Only send for txs that previously matched filters.
-							handler.txStateChannel.Add(TxState{
-								ListenerMsgTxStateCancel,
-								confHash,
-							})
-						}
-					}
-				}
-			}
-		}
-
-		// Perform any block cleanup
-		if err := handler.blockProcessor.ProcessBlock(ctx, block); err != nil {
-			logger.Debug(ctx, "Failed clean up after block : %s", hash)
-			handler.txs.ReleaseUnconfirmed(ctx) // Release unconfirmed
-			return nil, err
-		}
-
-		if !handler.state.IsReady() {
-			if handler.state.IsPendingSync() && handler.state.BlockRequestsEmpty() {
-				handler.state.SetInSync()
-				logger.Info(ctx, "Blocks in sync at height %d", handler.blocks.LastHeight())
-			}
-		}
-
-		if err := handler.txs.FinalizeUnconfirmed(ctx, unconfirmed); err != nil {
-			return nil, err
-		}
-	}
-
-	// Request more blocks
-	response := []wire.Message{}
-	getBlocks := wire.NewMsgGetData() // Block request message
-
-	for {
-		requestHash, _ := handler.state.GetNextBlockToRequest()
-		if requestHash == nil {
-			break
-		}
-
-		logger.Debug(ctx, "Requesting block : %s", requestHash)
-		getBlocks.AddInvVect(wire.NewInvVect(wire.InvTypeBlock, requestHash))
-		if len(getBlocks.InvList) == wire.MaxInvPerMsg {
-			// Start new get data (block request) message
-			response = append(response, getBlocks)
-			getBlocks = wire.NewMsgGetData()
-		}
-	}
-
-	// Add any non-full requests.
-	if len(getBlocks.InvList) > 0 {
-		response = append(response, getBlocks)
-	}
-
-	return response, nil
-}
-
-func containsHash(hash bitcoin.Hash32, list []bitcoin.Hash32) bool {
-	for _, listhash := range list {
-		if hash.Equal(&listhash) {
-			return true
-		}
-	}
-	return false
-}
-
-func removeHash(hash bitcoin.Hash32, list []bitcoin.Hash32) (bool, []bitcoin.Hash32) {
-	for i, listhash := range list {
-		if hash.Equal(&listhash) {
-			return true, append(list[:i], list[i+1:]...)
-		}
-	}
-	return false, list
-}
-
-// validateMerkleHash validates the merkle root hash against the transactions contained.
-// Returns true if the merkle root hash is valid.
-func validateMerkleHash(ctx context.Context, block *wire.MsgBlock) (bool, error) {
-	merkleHash, err := CalculateMerkleHash(ctx, block.Transactions)
-	if err != nil {
-		return false, err
-	}
-	return *merkleHash == block.Header.MerkleRoot, nil
-}
-
-// CalculateMerkleHash calculates a merkle tree root hash for a set of transactions
-func CalculateMerkleHash(ctx context.Context, txs []*wire.MsgTx) (*bitcoin.Hash32, error) {
-	if len(txs) == 0 {
-		// Zero hash
-		result, err := bitcoin.NewHash32FromStr("0000000000000000000000000000000000000000000000000000000000000000")
-		return result, err
-	}
-	if len(txs) == 1 {
-		// Hash of only tx
-		result := txs[0].TxHash()
-		return result, nil
-	}
-
-	// Tree root hash
-	hashes := make([]*bitcoin.Hash32, 0, len(txs))
-	for _, tx := range txs {
-		hash := tx.TxHash()
-		hashes = append(hashes, hash)
-	}
-	return CalculateMerkleLevel(ctx, hashes), nil
-}
-
-// CalculateMerkleLevel calculates one level of the merkle tree
-func CalculateMerkleLevel(ctx context.Context, txids []*bitcoin.Hash32) *bitcoin.Hash32 {
-	if len(txids) == 1 {
-		return combinedHash(ctx, txids[0], txids[0]) // Hash it with itself
-	}
-
-	if len(txids) == 2 {
-		return combinedHash(ctx, txids[0], txids[1]) // Hash both together
-	}
-
-	// More level calculations required (recursive)
-	// Combine every two hashes and put them in a list to process again.
-	nextLevel := make([]*bitcoin.Hash32, 0, (len(txids)/2)+1)
-	var tx1 *bitcoin.Hash32 = nil
-	for _, txid := range txids {
-		if tx1 == nil {
-			tx1 = txid
-			continue
-		}
-		nextLevel = append(nextLevel, combinedHash(ctx, tx1, txid))
-		tx1 = nil
-	}
-
-	// If there is a remainder, hash it with itself
-	if tx1 != nil {
-		nextLevel = append(nextLevel, combinedHash(ctx, tx1, tx1))
-	}
-
-	return CalculateMerkleLevel(ctx, nextLevel)
-}
-
-// combinedHash combines two hashes
-func combinedHash(ctx context.Context, hash1 *bitcoin.Hash32, hash2 *bitcoin.Hash32) *bitcoin.Hash32 {
-	data := make([]byte, bitcoin.Hash32Size*2)
-	copy(data[:bitcoin.Hash32Size], hash1[:])
-	copy(data[bitcoin.Hash32Size:], hash2[:])
-	result, _ := bitcoin.NewHash32(bitcoin.DoubleSha256(data))
-	return result
+	return nil, nil
 }

--- a/pkg/spynode/handlers/storage/transactions.go
+++ b/pkg/spynode/handlers/storage/transactions.go
@@ -399,7 +399,7 @@ func (repo *TxRepository) save(ctx context.Context) error {
 	data := make([]byte, 0, (unconfirmedTxSize*len(repo.unconfirmed))+1)
 	writer := bytes.NewBuffer(data)
 	version := uint8(0)
-	err := binary.Write(writer, binary.LittleEndian, version) // Milliseconds
+	err := binary.Write(writer, binary.LittleEndian, version)
 	if err != nil {
 		return err
 	}

--- a/pkg/spynode/outgoing.go
+++ b/pkg/spynode/outgoing.go
@@ -20,7 +20,9 @@ var (
 )
 
 // Send a message requesting headers after the latest seen
-func buildHeaderRequest(ctx context.Context, protocol uint32, blocks *storage.BlockRepository, delta int, max int) (*wire.MsgGetHeaders, error) {
+func buildHeaderRequest(ctx context.Context, protocol uint32, blocks *storage.BlockRepository,
+	delta int, max int) (*wire.MsgGetHeaders, error) {
+
 	getheaders := wire.NewMsgGetHeaders()
 	getheaders.ProtocolVersion = protocol
 

--- a/pkg/spynode/transactions.go
+++ b/pkg/spynode/transactions.go
@@ -1,0 +1,183 @@
+package spynode
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/tokenized/smart-contract/pkg/logger"
+	"github.com/tokenized/smart-contract/pkg/spynode/handlers"
+	"github.com/tokenized/smart-contract/pkg/wire"
+)
+
+// HandleTx processes a tx through spynode as if it came from the network.
+// Used to feed "response" txs directly back through spynode.
+func (node *Node) HandleTx(ctx context.Context, tx *wire.MsgTx) error {
+	return node.unconfTxChannel.Add(handlers.TxData{Msg: tx, Trusted: true, Safe: true,
+		ConfirmedHeight: -1})
+}
+
+func (node *Node) processConfirmedTx(ctx context.Context, tx handlers.TxData) error {
+	hash := tx.Msg.TxHash()
+
+	if tx.ConfirmedHeight == -1 {
+		return errors.New("Process confirmed tx with no height")
+	}
+
+	// Send full tx to listener if we aren't in sync yet and don't have a populated mempool.
+	// Or if it isn't in the mempool (not sent to listener yet).
+	isRelevant := false
+	if handlers.MatchesFilter(ctx, tx.Msg, node.txFilters) {
+		for _, listener := range node.listeners {
+			if rel, _ := listener.HandleTx(ctx, tx.Msg); rel {
+				isRelevant = true
+			}
+		}
+	}
+
+	if isRelevant {
+		// Notify of confirm
+		node.txStateChannel.Add(handlers.TxState{
+			handlers.ListenerMsgTxStateConfirm,
+			*hash,
+		})
+
+		// Add to txs for block
+		if _, _, err := node.txs.Add(ctx, *hash, tx.Trusted, tx.Safe, tx.ConfirmedHeight); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (node *Node) processUnconfirmedTx(ctx context.Context, tx handlers.TxData) error {
+	hash := tx.Msg.TxHash()
+
+	if tx.ConfirmedHeight != -1 {
+		return errors.New("Process unconfirmed tx with height")
+	}
+
+	node.txTracker.Remove(ctx, *hash)
+
+	// The mempool is needed to track which transactions have been sent to listeners and to check
+	//   for attempted double spends.
+	conflicts, trusted, added := node.memPool.AddTransaction(ctx, tx.Msg, tx.Trusted)
+	if !added {
+		return nil // Already saw this tx
+	}
+
+	logger.Debug(ctx, "Tx mempool (added %t) (flagged trusted %t) (received trusted %t) : %s",
+		added, trusted, tx.Trusted, hash.String())
+
+	if trusted {
+		// Was marked trusted in the mempool by a tx inventory from the trusted node.
+		// tx.Trusted means the tx itself was received from the trusted node.
+		tx.Trusted = trusted
+	}
+
+	if len(conflicts) > 0 {
+		logger.Warn(ctx, "Found %d conflicts with %s", len(conflicts), hash)
+		// Notify of attempted double spend
+		for _, conflict := range conflicts {
+			isRelevant, err := node.txs.MarkUnsafe(ctx, conflict)
+			if err != nil {
+				return errors.Wrap(err, "Failed to check tx repo")
+			}
+			if !isRelevant {
+				continue // Only send for txs that previously matched filters.
+			}
+
+			node.txStateChannel.Add(handlers.TxState{
+				handlers.ListenerMsgTxStateUnsafe,
+				conflict,
+			})
+		}
+	}
+
+	// We have to succesfully add to tx repo because it is protected by a lock and will prevent
+	//   processing the same tx twice at the same time.
+	added, newlySafe, err := node.txs.Add(ctx, *hash, tx.Trusted, tx.Safe, -1)
+	if err != nil {
+		return errors.Wrap(err, "Failed to add to tx repo")
+	}
+	if !added {
+		return nil // tx already processed
+	}
+
+	logger.Debug(ctx, "Tx repo (added %t) (newly safe %t) : %s", added, newlySafe, hash.String())
+
+	isRelevant := false
+	if !handlers.MatchesFilter(ctx, tx.Msg, node.txFilters) {
+		if _, err := node.txs.Remove(ctx, *hash, -1); err != nil {
+			return errors.Wrap(err, "Failed to remove from tx repo")
+		}
+		return nil // Filter out
+	}
+
+	// Notify of new tx
+	for _, listener := range node.listeners {
+		if rel, _ := listener.HandleTx(ctx, tx.Msg); rel {
+			if !isRelevant {
+				isRelevant = true
+			}
+		}
+	}
+
+	if !isRelevant {
+		// Remove from tx repository
+		if _, err := node.txs.Remove(ctx, *hash, -1); err != nil {
+			return errors.Wrap(err, "Failed to remove from tx repo")
+		}
+		return nil
+	}
+
+	// Notify of conflicting txs
+	if len(conflicts) > 0 {
+		node.txs.MarkUnsafe(ctx, *hash)
+		node.txStateChannel.Add(handlers.TxState{
+			handlers.ListenerMsgTxStateUnsafe,
+			*hash,
+		})
+	} else if (added && tx.Safe) || newlySafe {
+		// Note: A tx can be marked safe without being marked trusted if it is created internally.
+		node.txStateChannel.Add(handlers.TxState{
+			handlers.ListenerMsgTxStateSafe,
+			*hash,
+		})
+	}
+
+	return nil
+}
+
+// processUnconfirmedTxs pulls txs from the unconfirmed tx channel and processes them.
+func (node *Node) processUnconfirmedTxs(ctx context.Context) {
+	for tx := range node.unconfTxChannel.Channel {
+		if err := node.processUnconfirmedTx(ctx, tx); err != nil {
+			logger.Error(ctx, "SpyNodeAborted to process unconfirmed tx : %s : %s", err,
+				tx.Msg.TxHash().String())
+			node.requestStop(ctx)
+			break
+		}
+	}
+}
+
+// processConfirmedTxs pulls txs from the confiremd tx channel and processes them.
+func (node *Node) processConfirmedTxs(ctx context.Context) {
+	for tx := range node.confTxChannel.Channel {
+		if err := node.processConfirmedTx(ctx, tx); err != nil {
+			logger.Error(ctx, "SpyNodeAborted to process confirmed tx : %s : %s", err,
+				tx.Msg.TxHash().String())
+			node.requestStop(ctx)
+			break
+		}
+	}
+}
+
+// processhandlers.TxStates pulls txs from the tx state channel and processes them.
+func (node *Node) processTxStates(ctx context.Context) {
+	for txState := range node.txStateChannel.Channel {
+		for _, listener := range node.listeners {
+			listener.HandleTxState(ctx, txState.MsgType, txState.TxId)
+		}
+	}
+}

--- a/pkg/wire/msgblock_test.go
+++ b/pkg/wire/msgblock_test.go
@@ -578,3 +578,34 @@ var blockOneBytes = []byte{
 var blockOneTxLocs = []TxLoc{
 	{TxStart: 81, TxLen: 134},
 }
+
+func TestMerkleRoot(t *testing.T) {
+	// Merkle test (Bitcoin SV Block 570,666)
+	merkleTxIdStrings := []string{
+		"9e7447228f71e65ac0bcce3898f3a9a3e3e3ef89f1a07045f9565d8ef8da5c6d",
+		"26d732c0e4657e93b7143dcf7e25e93f61f630a5d465e3368f69708c57f69dd7",
+		"5fe54352f91acb9a2aff9b1271a296331d3bed9867be430f21ee19ef054efb0c",
+		"496eae8dbe3968884296b3bf078a6426de459afd710e8713645955d9660afad1",
+		"5809a72ee084625365067ff140c0cfedd05adc7a8a5040399409e9cca8ab4255",
+		"2a7927d2f953770fcd899902975ad7067a1adef3f572d5d8d196bfe0cbc7d954",
+	}
+	merkleTxIds := make([]*bitcoin.Hash32, 0, 6)
+	for _, hashString := range merkleTxIdStrings {
+		hash, err := bitcoin.NewHash32FromStr(hashString)
+		if err != nil {
+			t.Fatalf("Failed to create hash : %v", err)
+		}
+		merkleTxIds = append(merkleTxIds, hash)
+	}
+
+	merkleRoot := calculateMerkleLevel(merkleTxIds)
+	t.Logf("Merkle Test : %s", merkleRoot.String())
+
+	correctMerkleRoot, err := bitcoin.NewHash32FromStr("5f7b966b938cdb0dbf08a6bcd53e8854a6583b211452cf5dd5214dddd286e923")
+	if err != nil {
+		t.Fatalf("Failed to create hash : %s", err)
+	}
+	if *merkleRoot != *correctMerkleRoot {
+		t.Fatalf("Failed merkle root hash calculation, should be : %s", correctMerkleRoot.String())
+	}
+}

--- a/pkg/wire/msgblock_test.go
+++ b/pkg/wire/msgblock_test.go
@@ -605,7 +605,7 @@ func TestMerkleRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create hash : %s", err)
 	}
-	if *merkleRoot != *correctMerkleRoot {
+	if !merkleRoot.Equal(correctMerkleRoot) {
 		t.Fatalf("Failed merkle root hash calculation, should be : %s", correctMerkleRoot.String())
 	}
 }


### PR DESCRIPTION
Clean up block handling design and move to top level so it runs in its own thread. Making it more efficient and possibly allowing future distribution of block downloading.

Fix a retry bug in S3 storage remove function that was preventing it from returning until exhausting retries.