### PR TITLE
Fix timing issue with processing blocks and headers.

### DIFF
--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -1,15 +1,5 @@
 package identity
 
-import (
-	"context"
-	"testing"
-
-	"github.com/tokenized/smart-contract/pkg/bitcoin"
-	"github.com/tokenized/specification/dist/golang/actions"
-	"github.com/tokenized/specification/dist/golang/assets"
-	"github.com/tokenized/specification/dist/golang/protocol"
-)
-
 const baseURL = "http://localhost:8081"
 
 // func TestRegister(t *testing.T) {

--- a/pkg/identity/receive.go
+++ b/pkg/identity/receive.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/tokenized/smart-contract/pkg/bitcoin"
-	"github.com/tokenized/smart-contract/pkg/logger"
 
 	"github.com/tokenized/specification/dist/golang/actions"
 	"github.com/tokenized/specification/dist/golang/protocol"
@@ -111,8 +110,6 @@ func (o *Oracle) ValidateReceive(ctx context.Context, blocks BlockHashes, contra
 		return errors.Wrap(err, "signature hash")
 	}
 
-	logger.Info(ctx, "Validate receive signature hash : %x", sigHash)
-
 	signature, err := bitcoin.SignatureFromBytes(receiver.OracleConfirmationSig)
 	if err != nil {
 		return errors.Wrap(ErrInvalidSignature, "parse signature")
@@ -154,8 +151,6 @@ func (o *Oracle) ValidateReceiveHash(ctx context.Context, blockHash bitcoin.Hash
 	if err != nil {
 		return errors.Wrap(err, "signature hash")
 	}
-
-	logger.Info(ctx, "Validate receive signature hash : %x", sigHash)
 
 	signature, err := bitcoin.SignatureFromBytes(receiver.OracleConfirmationSig)
 	if err != nil {

--- a/pkg/spynode/handlers/handlers_test.go
+++ b/pkg/spynode/handlers/handlers_test.go
@@ -373,6 +373,10 @@ func (listener *TestListener) ProcessBlocks(ctx context.Context) error {
 		if err := listener.blocks.Add(ctx, &block.Header); err != nil {
 			return err
 		}
+
+		if err := listener.state.FinalizeBlock(*hash); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/spynode/handlers/headers.go
+++ b/pkg/spynode/handlers/headers.go
@@ -83,6 +83,7 @@ func (handler *HeadersHandler) Handle(ctx context.Context, m wire.Message) ([]wi
 		hash := header.BlockHash()
 
 		if lastHash.Equal(&header.PrevBlock) {
+			logger.Debug(ctx, "Header (next) : %s", hash.String())
 			request, err := handler.addHeader(ctx, header)
 			if err != nil {
 				return response, err
@@ -104,8 +105,10 @@ func (handler *HeadersHandler) Handle(ctx context.Context, m wire.Message) ([]wi
 			continue
 		}
 
+		logger.Debug(ctx, "Header (not next) : %s", hash.String())
+
 		if hash.Equal(lastHash) {
-			continue
+			continue // Already latest header
 		}
 
 		// Check if we already have this block
@@ -115,6 +118,7 @@ func (handler *HeadersHandler) Handle(ctx context.Context, m wire.Message) ([]wi
 		}
 
 		// Check for a reorg
+		logger.Info(ctx, "Header previous block : %s", header.PrevBlock.String())
 		reorgHeight, exists := handler.blocks.Height(&header.PrevBlock)
 		if exists {
 			logger.Info(ctx, "Reorging to height %d", reorgHeight)

--- a/pkg/spynode/handlers/storage/blocks.go
+++ b/pkg/spynode/handlers/storage/blocks.go
@@ -365,7 +365,7 @@ func (repo *BlockRepository) Revert(ctx context.Context, height int) error {
 		return errors.Wrap(err, fmt.Sprintf("Failed to read block file to truncate : %s", path))
 	}
 
-	if newCount < blocksPerKey {
+	if newCount < blocksPerKey && len(data) > wire.MaxBlockHeaderPayload*newCount {
 		data = data[:wire.MaxBlockHeaderPayload*newCount] // Truncate data
 
 		// Re-write file with truncated data


### PR DESCRIPTION
There was an issue that happened regularly during syncing, not very often during normal operation.

If a block was received. It was removed from the current block requests, then checked and added to the block repo. If during the time between when it was removed from block requests and when it was added to the block repo, spynode received its header again, then it would think there was a reorg, because it couldn't see that block, but it new it fit into the chain.

To fix it, the block isn't removed from block requests until after it is added to the block repo.