### PR TITLE
Block memory efficiency improvement

### DIFF
--- a/pkg/spynode/blocks.go
+++ b/pkg/spynode/blocks.go
@@ -104,16 +104,23 @@ func (node *Node) processBlocks(ctx context.Context) error {
 }
 
 // provideBlock feeds the block to the listeners.
-func (node *Node) provideBlock(ctx context.Context, block *wire.MsgBlock, height int) error {
+func (node *Node) provideBlock(ctx context.Context, block *wire.MsgParseBlock, height int) error {
 	hash := block.Header.BlockHash()
 	blockMessage := handlers.BlockMessage{Hash: *hash, Height: height, Time: block.Header.Timestamp}
 	for _, listener := range node.listeners {
 		listener.HandleBlock(ctx, handlers.ListenerMsgBlock, &blockMessage)
 	}
 
-	logger.Debug(ctx, "Providing block %d (%d tx) : %s", height, len(block.Transactions),
-		hash.String())
-	for _, tx := range block.Transactions {
+	logger.Debug(ctx, "Providing block %d (%d tx) : %s", height, block.TxCount, hash.String())
+	for {
+		tx, err := block.GetNextTx()
+		if err != nil {
+			return errors.Wrap(err, "get next tx")
+		}
+		if tx == nil {
+			break // parsed all txs
+		}
+
 		node.confTxChannel.Add(handlers.TxData{
 			Msg:             tx,
 			ConfirmedHeight: height,
@@ -123,7 +130,7 @@ func (node *Node) provideBlock(ctx context.Context, block *wire.MsgBlock, height
 	return nil
 }
 
-func (node *Node) ProcessBlock(ctx context.Context, block *wire.MsgBlock) error {
+func (node *Node) ProcessBlock(ctx context.Context, block *wire.MsgParseBlock) error {
 	node.blockLock.Lock()
 	defer node.blockLock.Unlock()
 
@@ -146,25 +153,20 @@ func (node *Node) ProcessBlock(ctx context.Context, block *wire.MsgBlock) error 
 	}
 
 	// Validate
-	valid, err := validateMerkleHash(ctx, block)
-	if err != nil {
-		node.state.FinalizeBlock(*hash)
-		return errors.Wrap(err, "Failed to validate merkle hash")
-	}
-	if !valid {
+	if !block.IsMerkleRootValid() {
 		logger.Warn(ctx, "Invalid merkle hash for block %s", hash.String())
 		node.state.FinalizeBlock(*hash)
 		return ErrBlockNotAdded
 	}
 
 	// Add to repo
-	if err = node.blocks.Add(ctx, &block.Header); err != nil {
+	if err := node.blocks.Add(ctx, &block.Header); err != nil {
 		node.state.FinalizeBlock(*hash)
 		return errors.Wrap(err, "add block")
 	}
 
 	// Remove from requested blocks
-	if err = node.state.FinalizeBlock(*hash); err != nil {
+	if err := node.state.FinalizeBlock(*hash); err != nil {
 		return errors.Wrap(err, "finialize block")
 	}
 
@@ -177,6 +179,7 @@ func (node *Node) ProcessBlock(ctx context.Context, block *wire.MsgBlock) error 
 
 	// Get unconfirmed "relevant" txs
 	var unconfirmed []bitcoin.Hash32
+	var err error
 	// This locks the tx repo so that propagated txs don't interfere while a block is being
 	//   processed.
 	unconfirmed, err = node.txs.GetUnconfirmed(ctx)
@@ -192,15 +195,19 @@ func (node *Node) ProcessBlock(ctx context.Context, block *wire.MsgBlock) error 
 	}
 
 	// Notify Tx for block and tx listeners
-	hashes, err := block.TxHashes()
-	if err != nil {
-		node.txs.ReleaseUnconfirmed(ctx) // Release unconfirmed
-		return errors.Wrap(err, "get block txs")
-	}
-
-	logger.Debug(ctx, "Processing block %d (%d tx) : %s", height, len(hashes), hash)
+	logger.Debug(ctx, "Processing block %d (%d tx) : %s", height, block.TxCount, hash)
 	inUnconfirmed := false
-	for i, txHash := range hashes {
+	for {
+		tx, err := block.GetNextTx()
+		if err != nil {
+			return errors.Wrap(err, "get next tx")
+		}
+		if tx == nil {
+			break // parsed all txs
+		}
+
+		txHash := tx.TxHash()
+
 		// Remove from unconfirmed. Only matching are in unconfirmed.
 		inUnconfirmed, unconfirmed = removeHash(*txHash, unconfirmed)
 
@@ -219,13 +226,13 @@ func (node *Node) ProcessBlock(ctx context.Context, block *wire.MsgBlock) error 
 		} else if !inMemPool {
 			// Not seen yet
 			node.confTxChannel.Add(handlers.TxData{
-				Msg:             block.Transactions[i],
+				Msg:             tx,
 				ConfirmedHeight: height,
 			})
 
 			// Transaction wasn't in the mempool.
 			// Check for transactions in the mempool with conflicting inputs (double spends).
-			if conflicting := node.memPool.Conflicting(block.Transactions[i]); len(conflicting) > 0 {
+			if conflicting := node.memPool.Conflicting(tx); len(conflicting) > 0 {
 				for _, confHash := range conflicting {
 					if containsHash(confHash, unconfirmed) { // Only send for txs that previously matched filters.
 						if err := node.txStateChannel.Add(handlers.TxState{
@@ -260,16 +267,6 @@ func (node *Node) ProcessBlock(ctx context.Context, block *wire.MsgBlock) error 
 	}
 
 	return nil
-}
-
-// validateMerkleHash validates the merkle root hash against the transactions contained.
-// Returns true if the merkle root hash is valid.
-func validateMerkleHash(ctx context.Context, block *wire.MsgBlock) (bool, error) {
-	merkleHash, err := block.CalculateMerkleHash()
-	if err != nil {
-		return false, err
-	}
-	return merkleHash.Equal(&block.Header.MerkleRoot), nil
 }
 
 func containsHash(hash bitcoin.Hash32, list []bitcoin.Hash32) bool {

--- a/pkg/spynode/handlers/block.go
+++ b/pkg/spynode/handlers/block.go
@@ -18,7 +18,6 @@ type BlockHandler struct {
 
 // NewBlockHandler returns a new BlockHandler with the given Config.
 func NewBlockHandler(state *data.State, blockRefeeder *BlockRefeeder) *BlockHandler {
-
 	result := BlockHandler{
 		state:         state,
 		blockRefeeder: blockRefeeder,
@@ -28,12 +27,12 @@ func NewBlockHandler(state *data.State, blockRefeeder *BlockRefeeder) *BlockHand
 
 // Handle implements the Handler interface for a block handler.
 func (handler *BlockHandler) Handle(ctx context.Context, m wire.Message) ([]wire.Message, error) {
-	block, ok := m.(*wire.MsgBlock)
+	block, ok := m.(*wire.MsgParseBlock)
 	if !ok {
-		return nil, errors.New("Could not assert as *wire.MsgBlock")
+		return nil, errors.New("Could not assert as *wire.MsgParseBlock")
 	}
 
-	receivedHash := block.BlockHash()
+	receivedHash := block.Header.BlockHash()
 	logger.Debug(ctx, "Received block : %s", receivedHash.String())
 
 	if handler.blockRefeeder != nil && handler.blockRefeeder.SetBlock(*receivedHash, block) {

--- a/pkg/spynode/handlers/block_refeeder.go
+++ b/pkg/spynode/handlers/block_refeeder.go
@@ -11,11 +11,11 @@ type BlockRefeeder struct {
 	nextHeight int
 	nextHash   bitcoin.Hash32
 	requested  bool
-	block      *wire.MsgBlock
+	block      *wire.MsgParseBlock
 	lock       sync.Mutex
 }
 
-func (br *BlockRefeeder) SetBlock(hash bitcoin.Hash32, block *wire.MsgBlock) bool {
+func (br *BlockRefeeder) SetBlock(hash bitcoin.Hash32, block *wire.MsgParseBlock) bool {
 	br.lock.Lock()
 	defer br.lock.Unlock()
 
@@ -27,7 +27,7 @@ func (br *BlockRefeeder) SetBlock(hash bitcoin.Hash32, block *wire.MsgBlock) boo
 	return false
 }
 
-func (br *BlockRefeeder) GetBlock() (*wire.MsgBlock, int, bool) {
+func (br *BlockRefeeder) GetBlock() (*wire.MsgParseBlock, int, bool) {
 	br.lock.Lock()
 	defer br.lock.Unlock()
 

--- a/pkg/spynode/handlers/data/requests.go
+++ b/pkg/spynode/handlers/data/requests.go
@@ -17,7 +17,7 @@ const (
 type requestedBlock struct {
 	hash  bitcoin.Hash32
 	time  time.Time // Time request was sent
-	block *wire.MsgBlock
+	block *wire.MsgParseBlock
 }
 
 func (state *State) BlockIsRequested(hash *bitcoin.Hash32) bool {
@@ -67,7 +67,7 @@ func (state *State) AddBlockRequest(hash *bitcoin.Hash32) bool {
 }
 
 // AddBlock adds the block message to the queued block request for later processing.
-func (state *State) AddBlock(hash *bitcoin.Hash32, block *wire.MsgBlock) bool {
+func (state *State) AddBlock(hash *bitcoin.Hash32, block *wire.MsgParseBlock) bool {
 	state.lock.Lock()
 	defer state.lock.Unlock()
 
@@ -81,7 +81,7 @@ func (state *State) AddBlock(hash *bitcoin.Hash32, block *wire.MsgBlock) bool {
 	return false
 }
 
-func (state *State) NextBlock() *wire.MsgBlock {
+func (state *State) NextBlock() *wire.MsgParseBlock {
 	state.lock.Lock()
 	defer state.lock.Unlock()
 

--- a/pkg/spynode/handlers/data/state.go
+++ b/pkg/spynode/handlers/data/state.go
@@ -24,7 +24,8 @@ type State struct {
 	startHeight        int               // Height of start block (to start pulling full blocks)
 	blocksRequested    []*requestedBlock // Blocks that have been requested
 	blocksToRequest    []bitcoin.Hash32  // Blocks that need to be requested
-	pendingSync        bool              // The peer has notified us of all blocks. Now we just have to process to catch up.
+	lastSavedHash      bitcoin.Hash32
+	pendingSync        bool // The peer has notified us of all blocks. Now we just have to process to catch up.
 	lock               sync.Mutex
 }
 

--- a/pkg/spynode/handlers/handlers_test.go
+++ b/pkg/spynode/handlers/handlers_test.go
@@ -110,6 +110,7 @@ func TestHandlers(test *testing.T) {
 		test.Errorf("Failed to get genesis hash : %s", err)
 		return
 	}
+	state.SetLastHash(*previousHash)
 	for i := 0; i < testBlockCount; i++ {
 		height := i
 

--- a/pkg/spynode/messages.go
+++ b/pkg/spynode/messages.go
@@ -1,0 +1,49 @@
+package spynode
+
+import (
+	"sync"
+
+	"github.com/tokenized/smart-contract/pkg/wire"
+
+	"github.com/pkg/errors"
+)
+
+type MessageChannel struct {
+	Channel chan wire.Message
+	lock    sync.Mutex
+	open    bool
+}
+
+func (c *MessageChannel) Add(msg wire.Message) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if !c.open {
+		return errors.New("Channel closed")
+	}
+
+	c.Channel <- msg
+	return nil
+}
+
+func (c *MessageChannel) Open(count int) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.Channel = make(chan wire.Message, count)
+	c.open = true
+	return nil
+}
+
+func (c *MessageChannel) Close() error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if !c.open {
+		return errors.New("Channel closed")
+	}
+
+	close(c.Channel)
+	c.open = false
+	return nil
+}

--- a/pkg/spynode/node.go
+++ b/pkg/spynode/node.go
@@ -131,6 +131,7 @@ func (node *Node) load(ctx context.Context) error {
 	if err := node.blocks.Load(ctx); err != nil {
 		return err
 	}
+	node.state.SetLastHash(*node.blocks.LastHash())
 	logger.Info(ctx, "Loaded blocks to height %d", node.blocks.LastHeight())
 	startHeight, exists := node.blocks.Height(&node.config.StartHash)
 	if exists {

--- a/pkg/spynode/untrusted_node.go
+++ b/pkg/spynode/untrusted_node.go
@@ -275,7 +275,7 @@ func (node *UntrustedNode) monitorIncoming(ctx context.Context) {
 		}
 
 		// read new messages, blocking
-		msg, _, err := wire.ReadMessage(node.connection, wire.ProtocolVersion,
+		_, msg, _, err := wire.ReadMessageParse(node.connection, wire.ProtocolVersion,
 			wire.BitcoinNet(node.config.Net))
 		if err != nil {
 			wireError, ok := errors.Cause(err).(*wire.MessageError)

--- a/pkg/spynode/untrusted_node.go
+++ b/pkg/spynode/untrusted_node.go
@@ -33,7 +33,7 @@ type UntrustedNode struct {
 	handlers        map[string]handlers.CommandHandler
 	connection      net.Conn
 	sendLock        sync.Mutex // Lock for sending on connection
-	outgoing        messageChannel
+	outgoing        MessageChannel
 	listeners       []handlers.Listener
 	txFilters       []handlers.TxFilter
 	stopping        bool
@@ -66,7 +66,6 @@ func NewUntrustedNode(address string, config data.Config, state *data.State, sto
 		txs:            txs,
 		txTracker:      data.NewTxTracker(),
 		memPool:        memPool,
-		outgoing:       messageChannel{},
 		listeners:      listeners,
 		txFilters:      txFilters,
 		txChannel:      txChannel,
@@ -473,44 +472,4 @@ func (node *UntrustedNode) sleepUntilStop(seconds int) {
 		}
 		time.Sleep(time.Second)
 	}
-}
-
-type messageChannel struct {
-	Channel chan wire.Message
-	lock    sync.Mutex
-	open    bool
-}
-
-func (c *messageChannel) Add(msg wire.Message) error {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	if !c.open {
-		return errors.New("Channel closed")
-	}
-
-	c.Channel <- msg
-	return nil
-}
-
-func (c *messageChannel) Open(count int) error {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	c.Channel = make(chan wire.Message, count)
-	c.open = true
-	return nil
-}
-
-func (c *messageChannel) Close() error {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	if !c.open {
-		return errors.New("Channel closed")
-	}
-
-	close(c.Channel)
-	c.open = false
-	return nil
 }

--- a/pkg/wire/msgparseblock.go
+++ b/pkg/wire/msgparseblock.go
@@ -1,0 +1,576 @@
+package wire
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"unicode/utf8"
+
+	"github.com/tokenized/smart-contract/pkg/bitcoin"
+
+	"github.com/pkg/errors"
+)
+
+// MsgParseBlock is a more efficient version of MsgBlock. It initially just determines the complete
+//   data set for the block and calculates the merkle root hash. Then allows each tx to be parsed
+//   one at a time and builds them using the same memory as the block data where possible.
+// The ReadMessageParse function must be used to receive a MsgParseBlock. The sole difference
+//   between ReadMessageParse and ReadMessage is that it returns a MsgParseBlock for CmdBlock
+//   commands.
+type MsgParseBlock struct {
+	Header     BlockHeader
+	MerkleRoot bitcoin.Hash32 // Calculated during initial parse
+	TxCount    uint64         // Total number of txs
+
+	pver     uint32
+	txOffset uint64 // Offset into data of the next tx
+	data     []byte
+}
+
+// IsMerkleRootValid returns true if the decoded block's calculated merkle root hash matches the
+//   header.
+func (mpb *MsgParseBlock) IsMerkleRootValid() bool {
+	return mpb.Header.MerkleRoot.Equal(&mpb.MerkleRoot)
+}
+
+// GetNextTx returns the next tx from the block.
+func (mpb *MsgParseBlock) GetNextTx() (*MsgTx, error) {
+	if uint64(len(mpb.data)) == mpb.txOffset {
+		return nil, nil // No txs left to parse
+	}
+
+	size, tx, err := ReadTxBytes(mpb.data[mpb.txOffset:], mpb.pver)
+	if err != nil {
+		return nil, errors.Wrap(err, "read tx")
+	}
+	mpb.txOffset += size
+	return tx, nil
+}
+
+// ResetTxs resets GetNextTx to the first tx in the block.
+func (mpb *MsgParseBlock) ResetTxs() {
+	mpb.txOffset = 0
+}
+
+// *************************************************************************************************
+// Message interface
+func (mpb *MsgParseBlock) BtcDecode(r io.Reader, pver uint32) error {
+	mpb.pver = pver // Save for tx decoding later
+
+	err := readBlockHeader(r, pver, &mpb.Header)
+	if err != nil {
+		return err
+	}
+
+	mpb.TxCount, err = ReadVarInt(r, pver)
+	if err != nil {
+		return err
+	}
+
+	// Prevent more transactions than could possibly fit into a block.
+	// It would be possible to cause memory exhaustion and panics without
+	// a sane upper bound on this count.
+	if mpb.TxCount > maxTxPerBlock {
+		str := fmt.Sprintf("too many transactions to fit into a block "+
+			"[count %d, max %d]", mpb.TxCount, maxTxPerBlock)
+		return messageError("MsgBlock.BtcDecode", str)
+	}
+
+	// Write all data read from this point on to the raw data for the block transactions so it can
+	//   be reparsed to process each tx.
+	var dataBuf bytes.Buffer
+	r = io.TeeReader(r, &dataBuf)
+
+	// Read the raw data for each tx and calculate it's hash so the merkle root hash can be
+	//   calculated.
+	txids := make([]*bitcoin.Hash32, 0, mpb.TxCount)
+	for i := uint64(0); i < mpb.TxCount; i++ {
+		txid, err := readTxId(r, pver) // Reads full tx data and returns the hash
+		if err != nil {
+			return err
+		}
+		txids = append(txids, &txid)
+	}
+
+	mpb.data = dataBuf.Bytes()
+
+	// Calculate merkle root hash
+	if mpb.TxCount == 1 {
+		mpb.MerkleRoot = *txids[0] // Special case : Use hash of only tx
+	} else {
+		mrh := calculateMerkleLevel(txids)
+		mpb.MerkleRoot = *mrh
+	}
+	return nil
+}
+
+func (mpb *MsgParseBlock) BtcEncode(w io.Writer, pver uint32) error {
+	err := writeBlockHeader(w, pver, &mpb.Header)
+	if err != nil {
+		return err
+	}
+
+	err = WriteVarInt(w, pver, uint64(mpb.TxCount))
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(mpb.data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (mpb *MsgParseBlock) Command() string {
+	return CmdBlock
+}
+
+func (mpb *MsgParseBlock) MaxPayloadLength(pver uint32) uint32 {
+	return MaxBlockPayload
+}
+
+// *************************************************************************************************
+
+func ReadMessageParse(r io.Reader, pver uint32, btcnet BitcoinNet) (int, Message, []byte, error) {
+	totalBytes := 0
+	n, hdr, err := readMessageHeader(r)
+	totalBytes += n
+	if err != nil {
+		if err == io.EOF {
+			return totalBytes, nil, nil, messageTypeError("ReadMessage",
+				MessageErrorConnectionClosed, err.Error())
+		}
+		return totalBytes, nil, nil, messageTypeError("ReadMessage", MessageErrorUndefined,
+			err.Error())
+	}
+
+	// Check for messages from the wrong bitcoin network.
+	if hdr.magic != btcnet {
+		discardInput(r, hdr.length)
+		str := fmt.Sprintf("[%v]", hdr.magic)
+		return totalBytes, nil, nil, messageTypeError("ReadMessage", MessageErrorWrongNetwork, str)
+	}
+
+	// Enforce maximum message payload.
+	if hdr.length > MaxMessagePayload {
+		str := fmt.Sprintf("message payload is too large - header "+
+			"indicates %d bytes, but max message payload is %d "+
+			"bytes.", hdr.length, MaxMessagePayload)
+		return totalBytes, nil, nil, messageError("ReadMessage", str)
+
+	}
+
+	// Check for malformed commands.
+	command := hdr.command
+	if !utf8.ValidString(command) {
+		discardInput(r, hdr.length)
+		return totalBytes, nil, nil, messageTypeError("ReadMessage", MessageErrorUnknownCommand,
+			command)
+	}
+
+	var msg Message
+	if command == CmdBlock { // Build MsgParseBlock instead of MsgBlock
+		msg = &MsgParseBlock{}
+	} else {
+		// Create struct of appropriate message type based on the command.
+		msg, err = makeEmptyMessage(command)
+		if err != nil {
+			discardInput(r, hdr.length)
+			return totalBytes, nil, nil, messageTypeError("ReadMessage", MessageErrorUnknownCommand,
+				command)
+		}
+	}
+
+	// Check for maximum length based on the message type as a malicious client
+	// could otherwise create a well-formed header and set the length to max
+	// numbers in order to exhaust the machine's memory.
+	mpl := msg.MaxPayloadLength(pver)
+	if hdr.length > mpl {
+		discardInput(r, hdr.length)
+		str := fmt.Sprintf("payload exceeds max length - header "+
+			"indicates %v bytes, but max payload size for "+
+			"messages of type [%v] is %v.", hdr.length, command, mpl)
+		return totalBytes, nil, nil, messageError("ReadMessage", str)
+	}
+
+	// Read payload.
+	payload := make([]byte, hdr.length)
+	n, err = io.ReadFull(r, payload)
+	totalBytes += n
+	if err != nil {
+		return totalBytes, nil, nil, err
+	}
+
+	// Test checksum.
+	checksum := bitcoin.DoubleSha256(payload)[0:4]
+	if !bytes.Equal(checksum, hdr.checksum[:]) {
+		str := fmt.Sprintf("payload checksum failed - header "+
+			"indicates %v, but actual checksum is %v.", hdr.checksum, checksum)
+		return totalBytes, nil, nil, messageError("ReadMessage", str)
+	}
+
+	// Unmarshal message.  NOTE: This must be a *bytes.Buffer since the
+	// MsgVersion BtcDecode function requires it.
+	if err := msg.BtcDecode(bytes.NewBuffer(payload), pver); err != nil {
+		return totalBytes, nil, nil, err
+	}
+
+	return totalBytes, msg, payload, nil
+}
+
+// readTxId reads the data for a full tx and returns the double SHA256 hash of it. It must take an
+//   io.Reader so that it can read from a net.Conn and wait for the data to be received. This does
+//   make it less efficient though because there is no skip function, so memory must be allocated to
+//   read past values that we don't actually care about.
+func readTxId(r io.Reader, pver uint32) (bitcoin.Hash32, error) {
+	// Tee reader into a buffer to calculate hash after reading.
+	var buf bytes.Buffer // To calculate hash
+	r = io.TeeReader(r, &buf)
+
+	if _, err := readTxSize(r, pver); err != nil {
+		return bitcoin.Hash32{}, errors.Wrap(err, "read tx size")
+	}
+
+	result, _ := bitcoin.NewHash32(bitcoin.DoubleSha256(buf.Bytes()))
+	return *result, nil
+}
+
+// readTxSize reads the data for a full tx and returns the size that it read. It must take an
+//   io.Reader so that it can read from a net.Conn and wait for the data to be received. This does
+//   make it less efficient though because there is no skip function, so memory must be allocated to
+//   read past values that we don't actually care about.
+func readTxSize(r io.Reader, pver uint32) (uint64, error) {
+	size := uint64(8) // fixed size of version and lock time
+	var fourbytes [4]byte
+
+	// Version
+	if _, err := r.Read(fourbytes[:]); err != nil {
+		return 0, errors.Wrap(err, "read version")
+	}
+
+	// Input count
+	var countSize, count uint64
+	var err error
+	countSize, count, err = ReadVarIntN(r, pver)
+	if err != nil {
+		return 0, errors.Wrap(err, "read input count")
+	}
+	size += countSize
+
+	// Prevent more input transactions than could possibly fit into a
+	// message.  It would be possible to cause memory exhaustion and panics
+	// without a sane upper bound on this count.
+	if count > uint64(maxTxInPerMessage) {
+		str := fmt.Sprintf("too many input transactions to fit into "+
+			"max message size [count %d, max %d]", count,
+			maxTxInPerMessage)
+		return 0, messageError("readTxSize", str)
+	}
+
+	// Inputs
+	for i := uint64(0); i < count; i++ {
+		inputSize, err := readInputSize(r, pver)
+		if err != nil {
+			return 0, errors.Wrap(err, "read input size")
+		}
+		size += inputSize
+	}
+
+	// Output count
+	countSize, count, err = ReadVarIntN(r, pver)
+	if err != nil {
+		return 0, errors.Wrap(err, "read output count")
+	}
+	size += countSize
+
+	// Prevent more output transactions than could possibly fit into a
+	// message.  It would be possible to cause memory exhaustion and panics
+	// without a sane upper bound on this count.
+	if count > uint64(maxTxOutPerMessage) {
+		str := fmt.Sprintf("too many output transactions to fit into "+
+			"max message size [count %d, max %d]", count,
+			maxTxOutPerMessage)
+		return 0, messageError("readTxSize", str)
+	}
+
+	// Outputs
+	for i := uint64(0); i < count; i++ {
+		outputSize, err := readOutputSize(r, pver)
+		if err != nil {
+			return 0, errors.Wrap(err, "read output size")
+		}
+		size += outputSize
+	}
+
+	// Lock Time
+	if _, err := r.Read(fourbytes[:]); err != nil {
+		return 0, errors.Wrap(err, "read lock time")
+	}
+
+	return size, nil
+}
+
+// readInputSize reads the data for a full bitcoin input and returns its size.
+func readInputSize(r io.Reader, pver uint32) (uint64, error) {
+	size := uint64(40) // fixed size of outpoint and sequence
+
+	// Outpoint
+	var outpoint [36]byte // 36 bytes for txid and index
+	if _, err := r.Read(outpoint[:]); err != nil {
+		return 0, errors.Wrap(err, "read outpoint")
+	}
+
+	// Unlocking script
+	scriptSize, err := readScriptSize(r, pver)
+	if err != nil {
+		return 0, errors.Wrap(err, "read script")
+	}
+	size += scriptSize
+
+	// Sequence
+	var sequence [4]byte
+	if _, err := r.Read(sequence[:]); err != nil {
+		return 0, errors.Wrap(err, "read sequence")
+	}
+
+	return size, nil
+}
+
+// readInputSize reads the data for a full bitcoin output and returns its size.
+func readOutputSize(r io.Reader, pver uint32) (uint64, error) {
+	size := uint64(8) // fixed size of value
+
+	// Value
+	var value [8]byte
+	_, err := r.Read(value[:])
+	if err != nil {
+		return 0, errors.Wrap(err, "read value")
+	}
+
+	// Locking script
+	scriptSize, err := readScriptSize(r, pver)
+	if err != nil {
+		return 0, errors.Wrap(err, "read script")
+	}
+	size += scriptSize
+
+	return size, nil
+}
+
+// readInputSize reads the data for a full bitcoin script and returns its size.
+func readScriptSize(r io.Reader, pver uint32) (uint64, error) {
+	var countSize, count uint64
+	var err error
+	countSize, count, err = ReadVarIntN(r, pver)
+	if err != nil {
+		return 0, errors.Wrap(err, "read script size")
+	}
+
+	script := make([]byte, count)
+	if _, err := r.Read(script); err != nil {
+		return 0, errors.Wrap(err, "read script data")
+	}
+
+	return countSize + count, nil
+}
+
+// ReadTxBytes reads a full tx and returns its size and the tx. It uses slices of the slice passed
+//   in to construct the slices within the tx.
+func ReadTxBytes(b []byte, pver uint32) (uint64, *MsgTx, error) {
+	result := &MsgTx{}
+	l := uint64(len(b))
+
+	// Version
+	if l < 4 {
+		return 0, nil, errors.Wrap(io.EOF, "read version")
+	}
+	result.Version = int32(endian.Uint32(b[:4]))
+
+	offset := uint64(4)
+
+	// Input count
+	var countSize, count uint64
+	var err error
+	countSize, count, err = ReadVarIntBytes(b[offset:], pver)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "read input count")
+	}
+	offset += countSize
+
+	// Inputs
+	result.TxIn = make([]*TxIn, 0, count)
+	for i := uint64(0); i < count; i++ {
+		inputSize, input, err := ReadInputBytes(b[offset:], pver)
+		if err != nil {
+			return 0, nil, errors.Wrap(err, "read input")
+		}
+
+		result.TxIn = append(result.TxIn, input)
+		offset += inputSize
+	}
+
+	// Output count
+	countSize, count, err = ReadVarIntBytes(b[offset:], pver)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "read output count")
+	}
+	offset += countSize
+
+	// Outputs
+	result.TxOut = make([]*TxOut, 0, count)
+	for i := uint64(0); i < count; i++ {
+		outputSize, output, err := ReadOutputBytes(b[offset:], pver)
+		if err != nil {
+			return 0, nil, errors.Wrap(err, "read output")
+		}
+
+		result.TxOut = append(result.TxOut, output)
+		offset += outputSize
+	}
+
+	// Lock Time
+	if l < offset+4 {
+		return 0, nil, errors.Wrap(io.EOF, "read lock time")
+	}
+	result.LockTime = endian.Uint32(b[offset : offset+4])
+	offset += 4
+
+	return offset, result, nil
+}
+
+func ReadInputBytes(b []byte, pver uint32) (uint64, *TxIn, error) {
+	result := &TxIn{}
+	offset := uint64(0)
+	l := uint64(len(b))
+
+	// Outpoint
+	if l < 36 {
+		return 0, nil, errors.Wrap(io.EOF, "read outpoint")
+	}
+	copy(result.PreviousOutPoint.Hash[:], b[offset:offset+bitcoin.Hash32Size])
+	offset += uint64(bitcoin.Hash32Size)
+
+	result.PreviousOutPoint.Index = endian.Uint32(b[offset : offset+4])
+	offset += 4
+
+	// Unlocking script
+	var scriptSize uint64
+	var err error
+	scriptSize, result.SignatureScript, err = ReadScriptBytes(b[offset:], pver)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "read script")
+	}
+	offset += scriptSize
+
+	// Sequence
+	if l < offset+4 {
+		return 0, nil, errors.Wrap(io.EOF, "read sequence")
+	}
+	result.Sequence = endian.Uint32(b[offset : offset+4])
+	offset += 4
+
+	return offset, result, nil
+}
+
+func ReadOutputBytes(b []byte, pver uint32) (uint64, *TxOut, error) {
+	result := &TxOut{}
+	offset := uint64(0)
+	l := uint64(len(b))
+
+	// Value
+	if l < 8 {
+		return 0, nil, errors.Wrap(io.EOF, "read value")
+	}
+	result.Value = endian.Uint64(b[:8])
+	offset += 8
+
+	// Locking script
+	var scriptSize uint64
+	var err error
+	scriptSize, result.PkScript, err = ReadScriptBytes(b[offset:], pver)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "read script")
+	}
+	offset += scriptSize
+
+	return offset, result, nil
+}
+
+func ReadScriptBytes(b []byte, pver uint32) (uint64, []byte, error) {
+	offset := uint64(0)
+
+	countSize, count, err := ReadVarIntBytes(b, pver)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "read script size")
+	}
+	offset += countSize
+
+	if uint64(len(b)) < offset+count {
+		return 0, nil, errors.Wrap(io.EOF, "read script")
+	}
+	script := b[offset : offset+count]
+	offset += count
+
+	return offset, script, nil
+}
+
+// ReadVarIntBytes reads a variable length integer from a byte slice and returns it's size and value
+//   as uint64s.
+func ReadVarIntBytes(b []byte, pver uint32) (uint64, uint64, error) {
+	discriminant := uint8(b[0])
+
+	switch discriminant {
+	case 0xff:
+		if len(b) < 9 {
+			return 0, 0, io.EOF
+		}
+		sv := endian.Uint64(b[1:9])
+
+		// The encoding is not canonical if the value could have been
+		// encoded using fewer bytes.
+		min := uint64(0x100000000)
+		if sv < min {
+			return 0, 0, messageError("ReadVarInt", fmt.Sprintf(errNonCanonicalVarInt, sv,
+				discriminant, min))
+		}
+
+		return 9, sv, nil
+
+	case 0xfe:
+		if len(b) < 5 {
+			return 0, 0, io.EOF
+		}
+		sv := endian.Uint32(b[1:5])
+
+		// The encoding is not canonical if the value could have been
+		// encoded using fewer bytes.
+		min := uint32(0x10000)
+		if sv < min {
+			return 0, 0, messageError("ReadVarInt", fmt.Sprintf(errNonCanonicalVarInt, sv,
+				discriminant, min))
+		}
+
+		return 5, uint64(sv), nil
+
+	case 0xfd:
+		if len(b) < 3 {
+			return 0, 0, io.EOF
+		}
+		sv := endian.Uint16(b[1:3])
+
+		// The encoding is not canonical if the value could have been
+		// encoded using fewer bytes.
+		min := uint16(0xfd)
+		if sv < min {
+			return 0, 0, messageError("ReadVarInt", fmt.Sprintf(errNonCanonicalVarInt, sv,
+				discriminant, min))
+		}
+
+		return 3, uint64(sv), nil
+
+	default:
+		return 1, uint64(discriminant), nil
+	}
+}

--- a/pkg/wire/msgparseblock_test.go
+++ b/pkg/wire/msgparseblock_test.go
@@ -1,0 +1,50 @@
+package wire
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tokenized/smart-contract/pkg/bitcoin"
+)
+
+func TestMsgParseBlockOne(t *testing.T) {
+	block := &MsgParseBlock{}
+
+	r := bytes.NewReader(blockOneBytes) // from msgblock_test.go
+	if err := block.BtcDecode(r, 1); err != nil {
+		t.Fatalf("Failed to decode parse block : %s", err)
+	}
+
+	count := block.TxCount
+	if count != 1 {
+		t.Fatalf("Wrong tx count : got %d, want %d", count, 1)
+	}
+
+	if !block.IsMerkleRootValid() {
+		t.Fatalf("Invalid merkle root hash : \n  got  %s\n  want %s", block.MerkleRoot.String(),
+			block.Header.MerkleRoot.String())
+	}
+
+	tx, err := block.GetNextTx()
+	if err != nil {
+		t.Fatalf("Failed to get first tx : %s", err)
+	}
+
+	if !tx.TxHash().Equal(&block.MerkleRoot) {
+		t.Fatalf("Invalid txid : \n  got  %s\n  want %s", tx.TxHash().String(),
+			block.MerkleRoot.String())
+	}
+
+	t.Logf("Tx : \n%s", tx.StringWithAddresses(bitcoin.MainNet))
+
+	tx2, err := block.GetNextTx()
+	if err != nil {
+		t.Fatalf("Failed to get second tx : %s", err)
+	}
+
+	if tx2 != nil {
+		t.Fatalf("Should not have gotten second tx : %s", tx2.TxHash().String())
+	}
+
+	t.Logf("No second tx")
+}


### PR DESCRIPTION
Implement a new wire block message and wire message reader to prevent a required interface change. The new block message only pre-parses txids to determine block tx data size and check the merkle root hash, then saves the block tx data. After that there is a function to parse one tx at a time and reuse as much block tx data as possible in the tx. This should allow processing larger blocks with less memory.

This also adds another check to prevent blocks getting out of order and a locking issue fix.