### PR TITLE
Add safety against multiple assets using one asset code.

### DIFF
--- a/cmd/smartcontractd/tests/tests_test.go
+++ b/cmd/smartcontractd/tests/tests_test.go
@@ -178,7 +178,8 @@ func checkResponse(t testing.TB, responseCode string) *wire.MsgTx {
 	}
 
 	response := responses[0].Copy()
-	responses = nil
+	responses = responses[1:]
+	remainingResponseCount := len(responses)
 	responseLock.Unlock()
 
 	var responseMsg actions.Action
@@ -215,7 +216,7 @@ func checkResponse(t testing.TB, responseCode string) *wire.MsgTx {
 	}
 
 	responseLock.Lock()
-	if len(responses) != 0 {
+	if len(responses) != remainingResponseCount {
 		responseLock.Unlock()
 		t.Fatalf("\t%s\tResponse created a response", tests.Failed)
 	}

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -240,7 +240,8 @@ func Move(ctx context.Context, dbConn *db.DB, contractAddress bitcoin.RawAddress
 	return nil
 }
 
-// AddAssetCode adds an asset code to a contract
+// AddAssetCode adds an asset code to a contract. If the asset code is already there, then it will
+//   not add it again.
 func AddAssetCode(ctx context.Context, dbConn *db.DB, contractAddress bitcoin.RawAddress,
 	assetCode *protocol.AssetCode, now protocol.Timestamp) error {
 	ctx, span := trace.StartSpan(ctx, "internal.contract.Update")
@@ -250,6 +251,12 @@ func AddAssetCode(ctx context.Context, dbConn *db.DB, contractAddress bitcoin.Ra
 	ct, err := Fetch(ctx, dbConn, contractAddress)
 	if err != nil {
 		return ErrNotFound
+	}
+
+	for _, ac := range ct.AssetCodes {
+		if ac.Equal(*assetCode) {
+			return nil
+		}
 	}
 
 	ct.AssetCodes = append(ct.AssetCodes, assetCode)

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/tokenized/smart-contract/pkg/bitcoin"
+
 	"github.com/tokenized/specification/dist/golang/actions"
 	"github.com/tokenized/specification/dist/golang/assets"
 	"github.com/tokenized/specification/dist/golang/protocol"
@@ -12,7 +13,7 @@ import (
 
 var (
 	urls = []string{
-		"http://localhost:8081", // Manually test by removing comment
+		// "http://localhost:8081", // Manually test by removing comment
 	}
 )
 


### PR DESCRIPTION
It was possible to submit multiple asset definition requests at the same time and if they were processed before the previous asset creation response, then they would get the wrong asset code.

This ensures the asset code is incremented when the asset definition is processed as well as being checked to ensure it is incremented when the asset creation is processed for recovery scenarios.